### PR TITLE
Run tests on Linux and x86 Mac

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -11,7 +11,7 @@ jobs:
   run-tinystories:
     strategy:
       matrix:
-        runner: [macos-12, macos-14, ubuntu-latest]
+        runner: [macos-12, ubuntu-latest]
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Also, move to M1 mac (by adding macos-14 to the matrix), but right now it's blocked by https://github.com/pytorch/pytorch/issues/123225 and https://github.com/pytorch/pytorch/issues/122705 (though later is occluded by pipe redirect)