### PR TITLE
int8 optimization for channel-wise evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,11 @@ Now you can run your model with the same command as before:
 python generate.py --pte-path ${MODEL_DIR}/${MODEL_NAME}_int8-gw256.pte --prompt "Hello my name is"
 ```
 
+Please note that group-wise quantization works functionally, but has
+not been optimized for CUDA and CPU targets where the best
+performnance requires a group-wise quantized mixed dtype linear
+operator.
+
 
 #### 4 bit integer quantization (8da4w)
 To compress your model even more, 4 bit integer quantization may be used.  To achieve good accuracy, we recommend the use

--- a/quantize.py
+++ b/quantize.py
@@ -328,9 +328,15 @@ class WeightOnlyInt8Linear(torch.nn.Module):
         weight = self.weight
         scales = scales.view(scales.shape[0], -1)
         no_groups = scales.shape[1]
-        #
-        return F.linear(input, (weight.to(dtype=input.dtype).view(weight.shape[0], no_groups, -1) * scales.view(weight.shape[0], no_groups, -1)).view(weight.shape[0], -1))
-        # return F.linear(input, self.weight.to(dtype=input.dtype)) * se...
+
+        # need a formulation / custom op for good performance on both eager, CUDA compiled, CPU compiled and ET exported
+        # maybe use IR-based rewriting?
+
+        # for now, we special-case channel-wise, because we know how to make that fast (but does not work for groupwise)
+        if scales.shape[1] == 1:
+            return F.linear(input, weight.to(dtype=input.dtype)) * self.scales
+        else:
+            return F.linear(input, (weight.to(dtype=input.dtype).view(weight.shape[0], no_groups, -1) * scales.view(weight.shape[0], no_groups, -1)).view(weight.shape[0], -1))
 
 
 ##### embedding table quantization ######


### PR DESCRIPTION
special-case channelwise int8 quantized lienar evaluation because we know how to make that fast for CUDA.

For consistent performance on CUDA and CPU with group-wise quantization need to create a new operator, possibly using a groupwise mixed dtype linear operator.