### PR TITLE
Update 'device=' setting for AOTI export

### DIFF
--- a/.github/workflows/compile_t4.yml
+++ b/.github/workflows/compile_t4.yml
@@ -43,8 +43,6 @@ jobs:
           export MODEL_PATH=checkpoints/stories15M/stories15M.pt
           export MODEL_NAME=stories15M
           export MODEL_DIR=/tmp
-          printenv
-          which nvidia-smi
           python generate.py --device cuda --checkpoint-path ${MODEL_PATH} --temperature 0 > ./output_eager
           cat ./output_eager
           python generate.py --device cuda --compile --checkpoint-path ${MODEL_PATH} --temperature 0 > ./output_compiled


### PR DESCRIPTION
With updated setting, AOTI-CUDA will try to compile, but currently fails on "CUDA_HOME" not set.