### PR TITLE
Fix name_to_dtype error in export.py

### DIFF
--- a/export.py
+++ b/export.py
@@ -23,7 +23,7 @@ from export_aoti import export_model as export_model_aoti
 
 from model import Transformer
 from generate import _load_model, decode_one_token
-from quantize import quantize_model
+from quantize import quantize_model, name_to_dtype
 from torch._export import capture_pre_autograd_graph
 
 default_device = "cpu"  # 'cuda' if torch.cuda.is_available() else 'cpu'
@@ -77,7 +77,7 @@ def main(checkpoint_path, device, quantize = "{ }", args = None):
     # dtype:
     if args.dtype:
         model.to(dtype=name_to_dtype(args.dtype))
-    
+
     model = model_wrapper(model, device=device)
 
     output_pte_path = args.output_pte_path


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/guangyang/llama-fast/export.py", line 186, in <module>
    cli()
  File "/home/guangyang/llama-fast/export.py", line 183, in cli
    main(args.checkpoint_path, args.device, args.quantize, args)
  File "/home/guangyang/llama-fast/export.py", line 79, in main
    model.to(dtype=name_to_dtype(args.dtype))
                   ^^^^^^^^^^^^^
NameError: name 'name_to_dtype' is not defined
```