### PR TITLE
Fix CI and validation scripts

### DIFF
--- a/.ci/scripts/validate.sh
+++ b/.ci/scripts/validate.sh
@@ -35,7 +35,7 @@ function generate_aoti_model_output() {
     local MODEL_NAME=$(basename "$CHECKPOINT_PATH" | sed 's/\.[^.]*$//')
     echo ""############### Run inference with AOTInductor for $MODEL_NAME "###############"
     python -W ignore export.py --checkpoint-path "$CHECKPOINT_PATH" --output-dso-path "${MODEL_DIR}/${MODEL_NAME}.so" --device "$TARGET_DEVICE"
-    python -W ignore generate.py --checkpoint-path "$CHECKPOINT_PATH" --dso-path "$MODEL_DIR/${MODEL_NAME}.so" --prompt "$PROMPT" > "$MODEL_DIR/output_aoti"
+    python -W ignore generate.py --checkpoint-path "$CHECKPOINT_PATH" --dso-path "$MODEL_DIR/${MODEL_NAME}.so" --prompt "$PROMPT" --device "$TARGET_DEVICE" > "$MODEL_DIR/output_aoti"
     cat "$MODEL_DIR/output_aoti"
 }
 
@@ -57,4 +57,7 @@ PROMPT="Hello, my name is"
 
 generate_compiled_model_output $CHECKPOINT_PATH $TARGET_DEVICE
 generate_aoti_model_output $CHECKPOINT_PATH $TARGET_DEVICE
-generate_executorch_model_output $CHECKPOINT_PATH $TARGET_DEVICE
+
+if [ $TARGET_DEVICE = "cpu" ]; then
+    generate_executorch_model_output $CHECKPOINT_PATH $TARGET_DEVICE
+fi

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -1,8 +1,10 @@
 name: pull
 
 on:
-  schedule:
-    - cron: '0,6,12,18 0 * * *'  # Runs at midnight UTC and every 6 hours
+  pull_request:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -21,7 +23,7 @@ jobs:
         id: gather-models
         run: |
           set -eux
-          PYTHONPATH="${PWD}" python .ci/scripts/gather_test_models.py
+          PYTHONPATH="${PWD}" python .ci/scripts/gather_test_models.py --event "pull_request"
   test-cpu:
     name: test-cpu (${{ matrix.platform }}, ${{ matrix.repo_name }})
     needs: gather-models
@@ -45,6 +47,7 @@ jobs:
           echo "$(uname -a)"
       - name: Install dependencies
         run: |
+          bash ${LLAMA_FAST_ROOT}/install_requirements.sh
           bash ${LLAMA_FAST_ROOT}/scripts/install_et.sh $ENABKE_ET_PYBIND
       - name: Download checkpoints
         run: |
@@ -55,3 +58,33 @@ jobs:
           export CHECKPOINT_PATH=${LLAMA_FAST_ROOT}/checkpoints/${REPO_NAME}/model.pth
           bash ${LLAMA_FAST_ROOT}/.ci/scripts/convert_checkpoint.sh ${REPO_NAME}
           bash ${LLAMA_FAST_ROOT}/.ci/scripts/validate.sh ${CHECKPOINT_PATH}
+  test-cuda:
+    name: test-cuda (linux, ${{ matrix.repo_name }})
+    needs: gather-models
+    strategy:
+      matrix: ${{ fromJSON(needs.gather-models.outputs.models) }}
+      fail-fast: false
+    runs-on: linux.g5.4xlarge.nvidia.gpu
+    gpu-arch-type: cuda
+    gpu-arch-version: "12.1"
+    env:
+      LLAMA_FAST_ROOT: ${{ github.workspace }}
+      REPO_NAME: ${{ matrix.repo_name }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Print machine info
+        run: |
+          echo "$(uname -a)"
+      - name: Install dependencies
+        run: |
+          bash ${LLAMA_FAST_ROOT}/install_requirements.sh cuda
+      - name: Download checkpoints
+        run: |
+          bash ${LLAMA_FAST_ROOT}/.ci/scripts/wget_checkpoint.sh ${{ matrix.repo_name }} "${{ matrix.resources }}"
+      - name: Run validation
+        run: |
+          pushd ${LLAMA_FAST_ROOT}
+          export CHECKPOINT_PATH=${LLAMA_FAST_ROOT}/checkpoints/${REPO_NAME}/model.pth
+          bash ${LLAMA_FAST_ROOT}/.ci/scripts/convert_checkpoint.sh ${REPO_NAME}
+          bash ${LLAMA_FAST_ROOT}/.ci/scripts/validate.sh ${CHECKPOINT_PATH} cuda

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -13,3 +13,15 @@ pip install torchao==0.1
 # Install lm-eval for Model Evaluation with lm-evalution-harness
 # Install tiktoken for tokenizer
 pip install lm-eval tiktoken blobfile
+
+DEVICE="${1:-cpu}"
+TORCH_CUDA_NIGHTLY_URL=https://download.pytorch.org/whl/nightly/cu121
+TORCH_NIGHTLY_URL=https://download.pytorch.org/whl/nightly/cpu
+
+if [ $DEVICE = "cuda" ]; then
+    pip install --pre torch torchvision torchaudio --index-url {TORCH_CUDA_NIGHTLY_URL}
+else
+    pip install --pre torch torchvision torchaudio --index-url {TORCH_NIGHTLY_URL}
+fi
+
+pip install -r ./requirements.txt


### PR DESCRIPTION
Fix an issue in the script to run on gpu.
Still want to cover the validation scripts in the CI but move expensive models out from running on pull requests (properly move to periodic.yml shortly).
Also squashed some refactoring to the setup scripts. Eventually when we launch, users should be easily run something to setup and validate what we claimed working, current setup scripts is not close to get there.