### PR TITLE
Some simple bug fixes in the scripts

### DIFF
--- a/.ci/scripts/wget_checkpoint.sh
+++ b/.ci/scripts/wget_checkpoint.sh
@@ -11,11 +11,9 @@ MODEL_REPO="$1"
 RESOURCES_STRING="$2"
 CHECKPOINT_NAME="${MODEL_REPO##*/}"
 
-pushd "${LLAMA_FAST_ROOT}" || exit
-
 # Create the directory for the checkpoint
 mkdir -p "checkpoints/${MODEL_REPO}"
-cd "checkpoints/${MODEL_REPO}" || exit
+pushd "checkpoints/${MODEL_REPO}" || exit
 
 # Download all resources
 IFS=',' # Set the field separator to comma


### PR DESCRIPTION
Fixed a bug of running the workflow.sh w/ cuda.
Make the script easier to use locally by passing a single model repo for validation/reproducing issues. For example, 
  1. `bash scripts/workflow.sh "cuda"` will run all models with all applicable workflows on CUDA
  2. `bash scripts/workflow.sh "cuda" "mistralai/Mistral-7B-v0.1"` will only run all applicable workflows for mistral-7b model
  3. `bash scripts/workflow.sh "cuda" "mistralai/Mistral-7B-v0.1" "aoti"` will only run AOT inductor path for mistral-7b model 