### PR TITLE
Fix syntax errors, misnamed identifiers

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -32,7 +32,7 @@ def check_args(args, command_name: str):
         raise RuntimeError(f"{command_name} is not a valid command")
     
     for disallowed in disallowed_args:
-        if args.hasattr(disallow):
+        if hasattr(args, disallowed):
             text = f"command {command_name} does not support option {disallowed.replace('_', '-')}"
             if strict:
                 raise RuntimeError(text)

--- a/eval.py
+++ b/eval.py
@@ -18,6 +18,9 @@ torch._inductor.config.epilogue_fusion = False
 torch._inductor.config.triton.cudagraphs = True
 torch._dynamo.config.cache_size_limit = 100000
 
+from cli import cli_args
+from quantize import name_to_dtype, set_precision
+
 from sentencepiece import SentencePieceProcessor
 
 from model import Transformer
@@ -196,7 +199,7 @@ def eval(
     return eval_results
 
 
-def main(args) -> None:
+def eval_main(args) -> None:
     """Evaluates model on a task from the `lm-evaluation-harness` library.
 
     Args:
@@ -278,9 +281,9 @@ def main(args) -> None:
         print(f"{task}: {res}")
 
 if __name__ == '__main__':
-def cli():
-    args = cli_args()
-    main(args)
+    def cli():
+        args = cli_args()
+        eval_main(args)
 
 
 if __name__ == "__main__":

--- a/torchat.py
+++ b/torchat.py
@@ -15,7 +15,7 @@ from torch.export import Dim, export
 from export import main as export_main
 from generate import main as generate_main
 from eval import eval_main
-from cli import cli_args
+from cli import cli_args, check_args
 
 default_device = "cpu"  # 'cuda' if torch.cuda.is_available() else 'cpu'
 


### PR DESCRIPTION
Fixing various minor issues I hit while trying to run Llama2-7b-chat. 

Tested on x86-64 Linux (5950x, 4090) via
```
python torchat.py --chat --checkpoint-path=checkpoints/meta-llama/Llama-2-7b-chat-hf/model.pth --tokenizer-path=checkpoints/meta-llama/Llama-2-7b-chat-hf/tokenizer.model --dtype fp16 --device cuda

python torchat.py --chat --checkpoint-path=checkpoints/meta-llama/Llama-2-7b-chat-hf/model.pth --tokenizer-path=checkpoints/meta-llama/Llama-2-7b-chat-hf/tokenizer.model --dtype fp16 --device cpu

python torchat.py --eval --checkpoint-path=checkpoints/meta-llama/Llama-2-7b-chat-hf/model.pth --tokenizer-path=checkpoints/meta-llama/Llama-2-7b-chat-hf/tokenizer.model --dtype fp16 --device cuda
```

Both CI failures appear to be crashes in AOTI.