### PR TITLE
Export new

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -31,7 +31,7 @@ try:
 except:
     lm_eval_available = False
 
-from generate import _load_inference_model, encode_tokens, model_forward
+from generate import _initialize_model, encode_tokens, model_forward
 
 if lm_eval_available:
     try: # lm_eval version 0.4
@@ -236,7 +236,7 @@ def eval_main(args) -> None:
     precision = name_to_dtype(model_dtype)
     set_precision(precision)
     
-    model = _load_inference_model(
+    model = _initialize_model(
         checkpoint_path,
         checkpoint_dir,
         params_path,

--- a/export.py
+++ b/export.py
@@ -25,7 +25,7 @@ except Exception as e:
 from export_aoti import export_model as export_model_aoti
 
 from model import Transformer
-from generate import _load_model, decode_one_token, _load_inference_model
+from generate import _load_model, decode_one_token, _initialize_model
 from quantize import quantize_model, name_to_dtype
 from torch._export import capture_pre_autograd_graph
 
@@ -53,7 +53,7 @@ def main(args):
     precision = name_to_dtype(args.dtype)  # torch.float  # bfloat16
     set_precision(precision)
     
-    model = _load_inference_model(
+    model = _initialize_model(
         args.checkpoint_path,
         args.checkpoint_dir,
         args.params_path,

--- a/generate.py
+++ b/generate.py
@@ -341,7 +341,7 @@ def _load_model(
 
 B_INST, E_INST = "[INST]", "[/INST]"
 
-def _load_inference_model(
+def _initialize_model(
         checkpoint_path,
         checkpoint_dir,
         params_path,
@@ -476,7 +476,7 @@ def _main(
     is_speculative = draft_checkpoint_path is not None
     is_chat = "chat" in str(checkpoint_path)
 
-    model = _load_inference_model(
+    model = _initialize_model(
         checkpoint_path,
         checkpoint_dir,
         params_path,
@@ -491,7 +491,7 @@ def _main(
         False, # use_tp
     )
 
-    # will add a version of _load_inference_model in future
+    # will add a version of _initialize_model in future
     # (need additional args)
     if is_speculative:
         draft_model = _load_model(


### PR DESCRIPTION
remove model wrapper, use shared model loader (already used for inference)
TODO: changed name of _load_inference_model function because now also used for export
