### PR TITLE
Fix readme to relfect new reponame

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ mistralai/Mistral-7B-Instruct-v0.2 | - | ✅ |  ✅ |  ✅ |  ✅ | ❹ |
 Currently `torchat` must be built via cloning the repository and installing as follows:
 
 ```
-git clone https://github.com/pytorch/torchat.git
-cd torchat
+git clone https://github.com/pytorch/torchchat.git
+cd torchchat
 pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #197

Summary:
att

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: