### PR TITLE
Make flake8 to be more opinionated

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,76 @@
+[flake8]
+select = B,C,E,F,P,W,B9,TOR0,TOR1,TOR2
+max-line-length = 120
+ignore =
+    # Black conflicts and overlaps.
+    B950,
+    E111,
+    E115,
+    E117,
+    E121,
+    E122,
+    E123,
+    E124,
+    E125,
+    E126,
+    E127,
+    E128,
+    E129,
+    E131,
+    E201,
+    E202,
+    E203,
+    E221,
+    E222,
+    E225,
+    E226,
+    E227,
+    E231,
+    E241,
+    E251,
+    E252,
+    E261,
+    E262,
+    E265,
+    E271,
+    E272,
+    E301,
+    E302,
+    E303,
+    E305,
+    E306,
+    E501,
+    E502,
+    E701,
+    E702,
+    E703,
+    E704,
+    W291,
+    W292,
+    W293,
+    W391,
+    W504,
+
+    # Too opinionated.
+    E265,
+    E266,
+    E402,
+    E722,
+    B001,
+    P207,
+    B003,
+    P208,
+    C403,
+    W503,
+
+    # Bugbear has opinions: https://github.com/PyCQA/flake8-bugbear#opinionated-warnings
+    B904,
+    B905,
+    B906,
+    B907,
+exclude =
+    ./.git,
+    *.pyi
+
+max-complexity = 12
+


### PR DESCRIPTION
It is consistent with ExecuTorch linter

Also increased 80 character limit to 120. Currently it is spitting out too many failures due to 80 limit. For now, let's increase it so that we can focus on the real issues

Test Plan: `lintrunner -a --all-files`
