### PR TITLE
Add Dynamic Quantized Partitioner along with General Partitioner

### DIFF
--- a/export_et.py
+++ b/export_et.py
@@ -13,8 +13,9 @@ from build.model import Transformer
 
 from executorch.backends.xnnpack.partition.xnnpack_partitioner import (
     XnnpackDynamicallyQuantizedPartitioner,
-    XnnpackPartitioner
+    XnnpackPartitioner,
 )
+
 # TODO: change back to executorch.examples.portable.utils
 # when executorch installs correctly
 


### PR DESCRIPTION
Use Dynamically quantized Partitioner along with normal partitioner in order to support dynamically quantized models.