### PR TITLE
Filter out infinitely small temperatures for float16

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -92,7 +92,7 @@ def multinomial_sample_one_no_sync(
 
 
 def logits_to_probs(logits, temperature: float = 1.0, top_k: Optional[int] = None):
-    logits = logits / max(temperature, 1e-5)
+    logits = logits / max(temperature, 1e-5 if logits.dtype != torch.float16 else 1e-3)
 
     if top_k is not None:
         v, _ = torch.topk(logits, min(top_k, logits.size(-1)))


### PR DESCRIPTION
$10^{-5}$ is too cold for fdtype, whose max is 65504.0 which is less than 100000

Fixes https://github.com/pytorch/torchchat/issues/250