### PR TITLE
Fix cmake for runner-et

### DIFF
--- a/runner-et/CMakeLists.txt
+++ b/runner-et/CMakeLists.txt
@@ -24,8 +24,12 @@ target_link_libraries(
         portable_kernels
         cpublas
         eigen_blas
+        optimized_native_cpu_ops_lib
 )
-target_link_libraries(runner_et PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,optimized_native_cpu_ops_lib">)
+target_link_options(
+  optimized_native_cpu_ops_lib INTERFACE "SHELL:LINKER:--whole-archive \
+  $<TARGET_FILE:optimized_native_cpu_ops_lib> \
+  LINKER:--no-whole-archive")
 target_link_libraries(runner_et PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,xnnpack_backend">)
 target_link_libraries(runner_et PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,XNNPACK">)
 target_link_libraries(runner_et PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,pthreadpool">)


### PR DESCRIPTION
Summary:
Ops are not registered without this fix, at least in my local build on x86 linux

Test Plan:
python export.py
--checkpoint-path <path-to-stories110M.pt>
--params-path <path-to-stories-110m-params.json>
--output-pte-path /tmp/stories110m.pte
cmake -S ./runner-et -B build/cmake-out -G Ninja
cmake --build ./build/cmake-out
./build/cmake-out/runner_et /tmp/stories110m.pte -z /tmp/tokenizer.bin -n 200 -t 0

Reviewers:

Subscribers:

Tasks:

Tags: