### PR TITLE
[BE] Do not use deprecated context manager

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -151,9 +151,8 @@ def decode_n_tokens(
 ):
     new_tokens, new_probs = [], []
     for _ in range(num_new_tokens):
-        with torch.backends.cuda.sdp_kernel(
-            enable_flash=False, enable_mem_efficient=False, enable_math=True
-        ):  # Actually better for Inductor to codegen attention here
+        # Actually better for Inductor to codegen attention here
+        with torch.nn.attention.sdpa_kernel([torch.nn.attention.SDPBackend.MATH]):
             next_token, next_prob = decode_one_token(
                 model, cur_token, input_pos, **sampling_kwargs
             )


### PR DESCRIPTION
`torch.backends.cuda.sdp_kernel`->`torch.nn.attention.sdpa_kernel`

Fixes following warning
```
FutureWarning: torch.backends.cuda.sdp_kernel() is deprecated. In the future, this context manager will be removed. Please see, torch.nn.attention.sdpa_kernel() for the new context manager, with updated signature.
```