### PR TITLE
Print some information about device we are running on

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -322,11 +322,22 @@ B_INST, E_INST = "[INST]", "[/INST]"
 def get_device_info(name: str) -> str:
     import platform
     from subprocess import check_output
+
     if name == "cpu":
         if platform.system() == "Darwin":
-            return check_output(["sysctl", "-n", "machdep.cpu.brand_string"]).decode("utf-8").strip()
+            return (
+                check_output(["sysctl", "-n", "machdep.cpu.brand_string"])
+                .decode("utf-8")
+                .strip()
+            )
         if platform.system() == "Linux":
-            return check_output(["sed", "-nr", "s/^model name\\s+: (.*)$/\\1/p", "/proc/cpuinfo"]).decode("utf-8").split("\n")[0]
+            return (
+                check_output(
+                    ["sed", "-nr", "s/^model name\\s+: (.*)$/\\1/p", "/proc/cpuinfo"]
+                )
+                .decode("utf-8")
+                .split("\n")[0]
+            )
     if name == "cuda":
         return torch.cuda.get_device_name(0)
     return ""


### PR DESCRIPTION
On Darwin, use sysctl to get machine name, on Linux, use `/proc/cpuinfo` and if CUDA device is used use `torch.cuda.get_device_name`

Also, change this logger.info to `print` as right now there are no way to control log levels from the generate script

This helps debug what's going on, should some issues arise