### PR TITLE
Add android build for runner-et

### DIFF
--- a/runner-et/CMakeLists.txt
+++ b/runner-et/CMakeLists.txt
@@ -1,6 +1,22 @@
 cmake_minimum_required(VERSION 3.24)
 set(CMAKE_CXX_STANDARD 17)
 
+IF(DEFINED ENV{ET_BUILD_DIR})
+  set(ET_BUILD_DIR $ENV{ET_BUILD_DIR})
+ELSE()
+  set(ET_BUILD_DIR "et-build")
+ENDIF()
+
+MESSAGE(STATUS "Using ET BUILD DIR: --[${ET_BUILD_DIR}]--")
+
+IF(DEFINED ENV{CMAKE_OUT_DIR})
+  set(CMAKE_OUT_DIR $ENV{CMAKE_OUT_DIR})
+ELSE()
+  set(CMAKE_OUT_DIR "cmake-out")
+ENDIF()
+
+MESSAGE(STATUS "Using ET BUILD DIR: --[${ET_BUILD_DIR}]--")
+
 project(Torchchat)
 
 include(CMakePrintHelpers)
@@ -8,8 +24,12 @@ include(Utils.cmake)
 set(TORCHCHAT_ROOT $ENV{TORCHCHAT_ROOT})
 cmake_print_variables(TORCHCHAT_ROOT)
 
-find_package(executorch CONFIG REQUIRED PATHS ${TORCHCHAT_ROOT}/et-build/install/lib/cmake/ExecuTorch)
-set(_common_include_directories ${TORCHCHAT_ROOT}/et-build/src)
+MESSAGE(STATUS "Looking for excutorch in ${TORCHCHAT_ROOT}/${ET_BUILD_DIR}/install/lib/cmake/ExecuTorch")
+set(executorch_DIR ${TORCHCHAT_ROOT}/${ET_BUILD_DIR}/install/lib/cmake/ExecuTorch)
+find_package(executorch CONFIG REQUIRED PATHS ${TORCHCHAT_ROOT}/${ET_BUILD_DIR}/install/lib/cmake/ExecuTorch)
+MESSAGE(STATUS "Found executorch cmake config.")
+
+set(_common_include_directories ${TORCHCHAT_ROOT}/${ET_BUILD_DIR}/src)
 cmake_print_variables(_common_include_directories)
 
 target_include_directories(executorch INTERFACE ${_common_include_directories}) # Ideally ExecuTorch installation process would do this
@@ -20,7 +40,7 @@ target_link_libraries(
     runner_et PRIVATE
         executorch
         extension_module
-        ${TORCHCHAT_ROOT}/et-build/src/executorch/cmake-out/extension/data_loader/libextension_data_loader.a # This one does not get installed by ExecuTorch
+        ${TORCHCHAT_ROOT}/${ET_BUILD_DIR}/src/executorch/${CMAKE_OUT_DIR}/extension/data_loader/libextension_data_loader.a # This one does not get installed by ExecuTorch
         optimized_kernels
         portable_kernels
         cpublas
@@ -32,6 +52,7 @@ target_link_libraries(
         pthreadpool
         cpuinfo
 )
+target_link_options_shared_lib(executorch)
 target_link_options_shared_lib(optimized_native_cpu_ops_lib)
 target_link_options_shared_lib(xnnpack_backend)
 target_link_options_shared_lib(XNNPACK)

--- a/runner-et/build_android.sh
+++ b/runner-et/build_android.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -ex
+
+if ["${ANDROID_NDK}" == ""]; then
+  echo "Please set ANDROID_NDK enviornment variable."
+  echo "For example it can be /Users/guest/Desktop/android-ndk-r26."
+  echo "You can download NDK from android website"
+  exit 1
+else
+  echo "ANDROID_NDK set to ${ANDROID_NDK}"
+fi
+
+export CMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake
+export DANDROID_ABI=arm64-v8a
+export DANDROID_PLATFORM=android-23 
+export ET_BUILD_DIR="et-build-android"
+export CMAKE_OUT_DIR="cmake-out-android"
+# export DCMAKE_INSTALL_PREFIX=cmake-out-android
+#
+
+install_executorch() {
+  echo "Cloning executorch to ${TORCHCHAT_ROOT}/${ET_BUILD_DIR}/src"
+  ET_BUILD_DIR="${TORCHCHAT_ROOT}/${ET_BUILD_DIR}"
+  rm -rf ${ET_BUILD_DIR}
+  mkdir -p ${ET_BUILD_DIR}/src
+  pushd ${ET_BUILD_DIR}/src
+  git clone https://github.com/pytorch/executorch.git
+  cd executorch
+  git checkout viable/strict
+  echo "Install executorch: submodule update"
+  git submodule sync
+  git submodule update --init
+
+  echo "Applying fixes"
+  cp ${TORCHCHAT_ROOT}/scripts/fixes_et/module.cpp ${ET_BUILD_DIR}/src/executorch/extension/module/module.cpp # ET uses non-standard C++ that does not compile in GCC
+  cp ${TORCHCHAT_ROOT}/scripts/fixes_et/managed_tensor.h ${ET_BUILD_DIR}/src/executorch/extension/runner_util/managed_tensor.h # ET is missing headers for vector/memory.  This causes downstream issues when building runner-et.
+
+  CMAKE_OUT_DIR="cmake-out-android"
+  echo "Building and installing C++ libraries"
+  echo "Inside: ${PWD}"
+  mkdir ${CMAKE_OUT_DIR}
+  cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=android-23 -DCMAKE_INSTALL_PREFIX=cmake-out-android -DEXECUTORCH_ENABLE_LOGGING=ON -DEXECUTORCH_LOG_LEVEL=Info -DEXECUTORCH_BUILD_OPTIMIZED=ON -DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=ON -DEXECUTORCH_BUILD_EXTENSION_MODULE=ON -DEXECUTORCH_BUILD_XNNPACK=ON -S . -B ${CMAKE_OUT_DIR} -G Ninja
+  cmake --build ${CMAKE_OUT_DIR}
+  cmake --install ${CMAKE_OUT_DIR} --prefix ${ET_BUILD_DIR}/install
+  popd
+}
+
+build_runner_et() {
+  rm -rf build/cmake-out-android
+  cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=android-23 -S ./runner-et -B build/cmake-out-android -G Ninja
+  cmake --build build/cmake-out-android/ -j16 --config Release
+}
+
+# install_executorch
+build_runner_et


### PR DESCRIPTION
Summary:
This enables us to benchmark models on android

Test Plan:
export ANDROID_NDK="path-to"
./runner-et/build_android.sh

adb push build/cmake-out-android/runner_et /data/local/tmp/ adb push /tmp/stories110m_a8w4dq.pte /data/local/tmp/ adb push /tmp/tokenizer.bin /data/local/tmp/
adb shell "cd /data/local/tmp/ && runner_et stories110m_fp32.pte -z tokenizer.bin  -n 200 -t 0" produced text
Once upon a time, there was a little girl named Lily. She loved to play outside in the sunshine.

<img width="1914" alt="image" src="https://github.com/pytorch/torchchat/assets/17488981/4308aef4-4fa9-4d10-832d-6593ac118ca4">

Reviewers:

Subscribers:

Tasks:

Tags: