### PR TITLE
Make builder.py compatible with Python-3.8

### DIFF
--- a/build/builder.py
+++ b/build/builder.py
@@ -9,7 +9,7 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 import torch
 import torch._dynamo.config
@@ -29,7 +29,7 @@ class BuilderArgs:
     params_path: Optional[Union[Path, str]] = None
     params_table: Optional[str] = None
     gguf_path: Optional[Union[Path, str]] = None
-    gguf_kwargs: Optional[dict[str, Any]] = None
+    gguf_kwargs: Optional[Dict[str, Any]] = None
     dso_path: Optional[Union[Path, str]] = None
     pte_path: Optional[Union[Path, str]] = None
     device: str = "cpu"


### PR DESCRIPTION
Before this change it fails with
```
    gguf_kwargs: Optional[dict[str, Any]] = None
TypeError: 'type' object is not subscriptable

```