### PR TITLE
Reduce period to run daily

### DIFF
--- a/.ci/scripts/gather_test_models.py
+++ b/.ci/scripts/gather_test_models.py
@@ -67,7 +67,7 @@ def model_should_run_on_event(model: str, event: str) -> bool:
     elif event == "push":
         return model in []
     elif event == "periodic":
-        return model in ["mistralai/Mistral-7B-v0.1", "openlm-research/open_llama_7b"]
+        return model in ["openlm-research/open_llama_7b"]
     else:
         return False
 

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -2,7 +2,7 @@ name: periodic
 
 on:
   schedule:
-    - cron: '0,6,12,18 0 * * *'  # Runs at midnight UTC and every 6 hours
+    - cron: '0 0 * * *'  # Runs daily at midnight UTC
   push:
     tags:
       - ciflow/periodic/*
@@ -107,15 +107,15 @@ jobs:
         run: |
           set -eux
           PYTHONPATH="${PWD}" python .ci/scripts/gather_test_models.py --event "periodic" --backend "gpu"
-  test-gpu-compile:
+  test-gpu:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
-    name: test-gpu-compile (${{ matrix.platform }}, ${{ matrix.model_name }})
+    name: test-gpu (${{ matrix.platform }}, ${{ matrix.model_name }})
     needs: gather-models-gpu
     strategy:
       matrix: ${{ fromJSON(needs.gather-models-gpu.outputs.models) }}
       fail-fast: false
     with:
-      runner: linux.g5.4xlarge.nvidia.gpu
+      runner: linux.g5.12xlarge.nvidia.gpu
       gpu-arch-type: cuda
       gpu-arch-version: "12.1"
       script: |
@@ -140,38 +140,5 @@ jobs:
 
         echo "::group::Run inference"
         bash .ci/scripts/validate.sh "./checkpoints/${REPO_NAME}/model.pth" "cuda" "compile"
-        echo "::endgroup::"
-  test-gpu-aoti:
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
-    name: test-gpu-aoti (${{ matrix.platform }}, ${{ matrix.model_name }})
-    needs: gather-models-gpu
-    strategy:
-      matrix: ${{ fromJSON(needs.gather-models-gpu.outputs.models) }}
-      fail-fast: false
-    with:
-      runner: linux.g5.4xlarge.nvidia.gpu
-      gpu-arch-type: cuda
-      gpu-arch-version: "12.1"
-      script: |
-        echo "::group::Print machine info"
-        nvidia-smi
-        echo "::endgroup::"
-
-        echo "::group::Install required packages"
-        pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu121
-        pip install -r ./requirements.txt
-        pip list
-        echo "::endgroup::"
-
-        echo "::group::Download checkpoint"
-        export REPO_NAME=${{ matrix.repo_name }}
-        bash .ci/scripts/wget_checkpoint.sh ${REPO_NAME} ${{ matrix.resources }}
-        echo "::endgroup::"
-
-        echo "::group::Convert checkpoint"
-        bash .ci/scripts/convert_checkpoint.sh ${REPO_NAME}
-        echo "::endgroup::"
-
-        echo "::group::Run inference"
         bash .ci/scripts/validate.sh "./checkpoints/${REPO_NAME}/model.pth" "cuda" "aoti"
         echo "::endgroup::"


### PR DESCRIPTION
As we are combining the dtypes and quants for each path (compile, aoti), it's taking longer for the job to finish a single run. I think for functionality and correctness guard (of course it will also provide the perf numbers), it's okay to just run a single 7b model once a day