### PR TITLE
[CLI] Cleaned up torchchat.py cli to include all of our options

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9,10 +9,28 @@ from pathlib import Path
 
 import torch
 
-default_device = "cpu"
+# CPU is always available and also exportable to ExecuTorch
+default_device = "cpu"  # 'cuda' if torch.cuda.is_available() else 'cpu'
 
 def check_args(args, name: str) -> None:
     pass
+
+def add_arguments_for_chat(parser):
+    # Only chat specific options should be here
+    _add_arguments_common(parser)
+
+
+def add_arguments_for_browser(parser):
+    # Only browser specific options should be here
+    _add_arguments_common(parser)
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=5000,
+        help="Port for the web server in browser mode"
+    )
+    _add_arguments_common(parser)
+
 
 def add_arguments_for_download(parser):
     # Only download specific options should be here
@@ -33,158 +51,204 @@ def add_arguments_for_export(parser):
     # Only export specific options should be here
     _add_arguments_common(parser)
 
-def add_arguments_for_browser(parser):
-    # Only browser specific options should be here
-    _add_arguments_common(parser)
-    parser.add_argument(
-        "--port",
-        type=int,
-        default=5000,
-        help="Port for the web server for browser mode."
-    )
 
 def _add_arguments_common(parser):
     # Model specification. TODO Simplify this.
     # A model can be specified using a positional model name or HuggingFace
     # path. Alternatively, the model can be specified via --gguf-path or via
     # an explicit --checkpoint-dir, --checkpoint-path, or --tokenizer-path.
-
     parser.add_argument(
         "model",
         type=str,
         nargs="?",
         default=None,
-        help="Model name for well-known models.",
+        help="Model name for well-known models",
     )
 
+
+def add_arguments(parser):
     # TODO: Refactor this so that only common options are here
-    # and subcommand-specific options are inside individual
+    # and command-specific options are inside individual
     # add_arguments_for_generate, add_arguments_for_export etc.
-    parser.add_argument(
-        "--seed",
-        type=int,
-        default=1234,  # set None for release
-        help="Initialize torch seed",
-    )
-    parser.add_argument(
-        "--prompt", type=str, default="Hello, my name is", help="Input prompt."
-    )
-    parser.add_argument(
-        "--tiktoken",
-        action="store_true",
-        help="Whether to use tiktoken tokenizer.",
-    )
+
     parser.add_argument(
         "--chat",
         action="store_true",
-        help="Use torchchat for an interactive chat session.",
-    )
-    parser.add_argument(
-        "--is-chat-model",
-        action="store_true",
-        help="Indicate that the model was trained to support chat functionality.",
+        help="Whether to start an interactive chat session",
     )
     parser.add_argument(
         "--gui",
         action="store_true",
-        help="Use torchchat to for an interactive gui-chat session.",
-    )
-    parser.add_argument("--num-samples", type=int, default=1, help="Number of samples.")
-    parser.add_argument(
-        "--max-new-tokens", type=int, default=200, help="Maximum number of new tokens."
-    )
-    parser.add_argument("--top-k", type=int, default=200, help="Top-k for sampling.")
-    parser.add_argument(
-        "--temperature", type=float, default=0.8, help="Temperature for sampling."
+        help="Whether to use a web UI for an interactive chat session",
     )
     parser.add_argument(
-        "--compile", action="store_true", help="Whether to compile the model."
+        "--prompt",
+        type=str,
+        default="Hello, my name is",
+        help="Input prompt",
+    )
+    parser.add_argument(
+        "--is-chat-model",
+        action="store_true",
+        help="Indicate that the model was trained to support chat functionality",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Initialize torch seed",
+    )
+    parser.add_argument(
+        "--tiktoken",
+        action="store_true",
+        help="Whether to use tiktoken tokenizer",
+    )
+    parser.add_argument(
+        "--num-samples",
+        type=int,
+        default=1,
+        help="Number of samples",
+    )
+    parser.add_argument(
+        "--max-new-tokens",
+        type=int,
+        default=200,
+        help="Maximum number of new tokens",
+    )
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        default=200,
+        help="Top-k for sampling",
+    )
+    parser.add_argument(
+        "--temperature",
+        type=float,
+        default=0.8,
+        help="Temperature for sampling"
+    )
+    parser.add_argument(
+        "--compile",
+        action="store_true",
+        help="Whether to compile the model with torch.compile",
     )
     parser.add_argument(
         "--compile-prefill",
         action="store_true",
-        help="Whether to compile the prefill (improves prefill perf, but higher compile times)",
+        help="Whether to compile the prefill. Improves prefill perf, but has higher compile times.",
     )
-    parser.add_argument("--profile", type=Path, default=None, help="Profile path.")
     parser.add_argument(
-        "--speculate-k", type=int, default=5, help="Speculative execution depth."
+        "--profile",
+        type=Path,
+        default=None,
+        help="Profile path.",
+    )
+    parser.add_argument(
+        "--speculate-k",
+        type=int,
+        default=5,
+        help="Speculative execution depth",
     )
     parser.add_argument(
         "--draft-checkpoint-path",
         type=Path,
         default=None,
-        help="Draft checkpoint path.",
+        help="Use the specified draft checkpoint path",
     )
     parser.add_argument(
         "--checkpoint-path",
         type=Path,
         default="not_specified",
-        help="Model checkpoint path.",
+        help="Use the specified model checkpoint path",
     )
-    # parser.add_argument(
-    #     "--checkpoint-dir",
-    #     type=Path,
-    #     default=None,
-    #     help="Model checkpoint directory.",
-    # )
     parser.add_argument(
         "--params-path",
         type=Path,
         default=None,
-        help="Parameter file path.",
+        help="Use the specified parameter file",
     )
     parser.add_argument(
         "--gguf-path",
         type=Path,
         default=None,
-        help="GGUF file path.",
+        help="Use the specified GGUF model file",
     )
     parser.add_argument(
         "--tokenizer-path",
         type=Path,
         default=None,
-        help="Model checkpoint path.",
+        help="Use the specified model tokenizer file",
     )
-    parser.add_argument("--output-pte-path", type=str, default=None, help="Filename")
-    parser.add_argument("--output-dso-path", type=str, default=None, help="Filename")
     parser.add_argument(
-        "--dso-path", type=Path, default=None, help="Use the specified AOTI DSO model."
+        "--output-pte-path",
+        type=str,
+        default=None,
+        help="Output to the specified ExecuTorch .pte model file",
+    )
+    parser.add_argument(
+        "--output-dso-path",
+        type=str,
+        default=None,
+        help="Output to the specified AOT Inductor .dso model file",
+    )
+    parser.add_argument(
+        "--dso-path",
+        type=Path,
+        default=None,
+        help="Use the specified AOT Inductor .dso model file",
     )
     parser.add_argument(
         "--pte-path",
         type=Path,
         default=None,
-        help="Use the specified Executorch PTE model.",
+        help="Use the specified ExecuTorch .pte model file",
     )
     parser.add_argument(
-        "-d",
-        "--dtype",
+        "-d", "--dtype",
         default="float32",
         help="Override the dtype of the model (default is the checkpoint dtype). Options: bf16, fp16, fp32",
     )
-    parser.add_argument("-v", "--verbose", action="store_true")
     parser.add_argument(
-        "--quantize", type=str, default="{ }", help="Quantization options."
+        "-v", "--verbose",
+        action="store_true",
+        help="Verbose output",
     )
-    parser.add_argument("--params-table", type=str, default=None, help="Device to use")
     parser.add_argument(
-        "--device", type=str, default=default_device, help="Device to use"
+        "--quantize",
+        type=str,
+        default="{ }",
+        help="Quantization options",
+    )
+    parser.add_argument(
+        "--params-table",
+        type=str,
+        default=None,
+        help="Parameter table to use",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default=default_device,
+        help="Hardware device to use. Options: cpu, gpu, mps",
     )
     parser.add_argument(
         "--tasks",
         nargs="+",
         type=str,
         default=["hellaswag"],
-        help="list of lm-eluther tasks to evaluate usage: --tasks task1 task2",
+        help="List of lm-eluther tasks to evaluate. Usage: --tasks task1 task2",
     )
     parser.add_argument(
-        "--limit", type=int, default=None, help="number of samples to evaluate"
+        "--limit",
+        type=int,
+        default=None,
+        help="Number of samples to evaluate",
     )
     parser.add_argument(
         "--max-seq-length",
         type=int,
         default=None,
-        help="maximum length sequence to evaluate",
+        help="Maximum length sequence to evaluate",
     )
     parser.add_argument(
         "--hf-token",
@@ -201,7 +265,6 @@ def _add_arguments_common(parser):
 
 
 def arg_init(args):
-
     if Path(args.quantize).is_file():
         with open(args.quantize, "r") as f:
             args.quantize = json.loads(f.read())

--- a/eval.py
+++ b/eval.py
@@ -20,7 +20,11 @@ from build.builder import (
 )
 
 from build.model import Transformer
-from cli import add_arguments_for_eval, arg_init
+from cli import (
+    add_arguments,
+    add_arguments_for_eval,
+    arg_init,
+)
 from download import download_and_convert, is_model_downloaded
 from generate import encode_tokens, model_forward
 
@@ -281,7 +285,8 @@ def main(args) -> None:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Export specific CLI.")
+    parser = argparse.ArgumentParser(description="torchchat eval CLI")
+    add_arguments(parser)
     add_arguments_for_eval(parser)
     args = parser.parse_args()
     args = arg_init(args)

--- a/export.py
+++ b/export.py
@@ -15,7 +15,12 @@ from build.builder import (
     _unset_gguf_kwargs,
     BuilderArgs,
 )
-from cli import add_arguments_for_export, arg_init, check_args
+from cli import (
+    add_arguments,
+    add_arguments_for_export,
+    arg_init,
+    check_args,
+)
 from download import download_and_convert, is_model_downloaded
 from export_aoti import export_model as export_model_aoti
 
@@ -106,7 +111,8 @@ def main(args):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Export specific CLI.")
+    parser = argparse.ArgumentParser(description="torchchat export CLI")
+    add_arguments(parser)
     add_arguments_for_export(parser)
     args = parser.parse_args()
     check_args(args, "export")

--- a/export_aoti.py
+++ b/export_aoti.py
@@ -10,6 +10,7 @@ import torch.nn as nn
 
 from torch.export import Dim
 
+# CPU is always available and also exportable to ExecuTorch
 default_device = "cpu"  # 'cuda' if torch.cuda.is_available() else 'cpu'
 
 

--- a/export_et.py
+++ b/export_et.py
@@ -30,6 +30,7 @@ from quantize import get_precision
 from torch._export import capture_pre_autograd_graph
 
 
+# CPU is always available and also exportable to ExecuTorch
 default_device = "cpu"  # 'cuda' if torch.cuda.is_available() else 'cpu'
 
 

--- a/generate.py
+++ b/generate.py
@@ -26,7 +26,12 @@ from build.builder import (
     TokenizerArgs,
 )
 from build.model import Transformer
-from cli import add_arguments_for_generate, arg_init, check_args
+from cli import (
+    add_arguments,
+    add_arguments_for_generate,
+    arg_init,
+    check_args,
+)
 from download import download_and_convert, is_model_downloaded
 from quantize import set_precision
 
@@ -568,7 +573,8 @@ def main(args):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Generate specific CLI.")
+    parser = argparse.ArgumentParser(description="torchchat generate CLI")
+    add_arguments(parser)
     add_arguments_for_generate(parser)
     args = parser.parse_args()
     check_args(args, "generate")

--- a/torchchat.py
+++ b/torchchat.py
@@ -10,11 +10,13 @@ import subprocess
 import sys
 
 from cli import (
+    add_arguments,
+    add_arguments_for_browser,
+    add_arguments_for_chat,
     add_arguments_for_download,
     add_arguments_for_eval,
     add_arguments_for_export,
     add_arguments_for_generate,
-    add_arguments_for_browser,
     arg_init,
     check_args,
 )
@@ -23,54 +25,89 @@ default_device = "cpu"  # 'cuda' if torch.cuda.is_available() else 'cpu'
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Top-level command")
+    # Initialize the top-level parser
+    parser = argparse.ArgumentParser(
+        prog="torchchat",
+        description="Welcome to the torchchat CLI!",
+        add_help=True,
+    )
+    # Default command is to print help
+    parser.set_defaults(func=lambda args: self._parser.print_help())
+
+    add_arguments(parser)
     subparsers = parser.add_subparsers(
-        dest="subcommand",
-        help="Use `download`, `generate`, `eval`, `export` or `browser` followed by subcommand specific options.",
+        dest="command",
+        help="The specific command to run",
     )
 
-    parser_download = subparsers.add_parser("download")
-    add_arguments_for_download(parser_download)
+    parser_chat = subparsers.add_parser(
+        "chat",
+        help="Chat interactively with a model",
+    )
+    add_arguments_for_chat(parser_chat)
 
-    parser_generate = subparsers.add_parser("generate")
-    add_arguments_for_generate(parser_generate)
-
-    parser_eval = subparsers.add_parser("eval")
-    add_arguments_for_eval(parser_eval)
-
-    parser_export = subparsers.add_parser("export")
-    add_arguments_for_export(parser_export)
-
-    parser_browser = subparsers.add_parser("browser")
+    parser_browser = subparsers.add_parser(
+        "browser",
+        help="Chat interactively in a browser",
+    )
     add_arguments_for_browser(parser_browser)
 
+    parser_download = subparsers.add_parser(
+        "download",
+        help="Download a model from Hugging Face or others",
+    )
+    add_arguments_for_download(parser_download)
+
+    parser_generate = subparsers.add_parser(
+        "generate",
+        help="Generate responses from a model given a prompt",
+    )
+    add_arguments_for_generate(parser_generate)
+
+    parser_eval = subparsers.add_parser(
+        "eval",
+        help="Evaluate a model given a prompt",
+    )
+    add_arguments_for_eval(parser_eval)
+
+    parser_export = subparsers.add_parser(
+        "export",
+        help="Export a model for AOT Inductor or ExecuTorch",
+    )
+    add_arguments_for_export(parser_export)
+
+    # Move all flags to the front of sys.argv since we don't
+    # want to use the subparser syntax
+    flag_args = []
+    positional_args = []
+    i = 1
+    while i < len(sys.argv):
+        if sys.argv[i].startswith("-"):
+            flag_args += sys.argv[i:i+2]
+            i += 2
+        else:
+            positional_args.append(sys.argv[i])
+            i += 1
+    sys.argv = sys.argv[:1] + flag_args + positional_args
+
+    # Now parse the arguments
     args = parser.parse_args()
     args = arg_init(args)
     logging.basicConfig(
         format="%(message)s", level=logging.DEBUG if args.verbose else logging.INFO
     )
 
-    if args.subcommand == "download":
-        check_args(args, "download")
-        from download import main as download_main
-
-        download_main(args)
-    elif args.subcommand == "generate":
-        check_args(args, "generate")
+    if args.command == "chat":
+        # enable "chat"
+        args.chat = True
+        check_args(args, "chat")
         from generate import main as generate_main
-
         generate_main(args)
-    elif args.subcommand == "eval":
-        from eval import main as eval_main
-
-        eval_main(args)
-    elif args.subcommand == "export":
-        check_args(args, "export")
-        from export import main as export_main
-
-        export_main(args)
-    elif args.subcommand == "browser":
-        # TODO: add check_args()
+    elif args.command == "browser":
+        # enable "chat" and "gui" when entering "browser"
+        args.chat = True
+        args.gui = True
+        check_args(args, "browser")
 
         # Look for port from cmd args. Default to 5000 if not found.
         # The port args will be passed directly to the Flask app.
@@ -88,12 +125,24 @@ if __name__ == "__main__":
             else:
                 i += 1
 
-        # Assume the user wants "chat" when entering "browser". TODO: add support for "generate" as well
-        args_plus_chat = ['"{}"'.format(s) for s in sys.argv[2:]] + ['"--chat"'] + ['"--num-samples"'] + ['"1000000"']
+        args_plus_chat = ['"{}"'.format(s) for s in sys.argv[2:]] + ["\"--chat\""]
         formatted_args = ", ".join(args_plus_chat)
         command = ["flask", "--app", "chat_in_browser:create_app(" + formatted_args + ")", "run", "--port", f"{port}"]
         subprocess.run(command)
+    elif args.command == "download":
+        check_args(args, "download")
+        from download import main as download_main
+        download_main(args)
+    elif args.command == "generate":
+        check_args(args, "generate")
+        from generate import main as generate_main
+        generate_main(args)
+    elif args.command == "eval":
+        from eval import main as eval_main
+        eval_main(args)
+    elif args.command == "export":
+        check_args(args, "export")
+        from export import main as export_main
+        export_main(args)
     else:
-        raise RuntimeError(
-            "Must specify a valid subcommand: download, generate, export, or eval."
-        )
+        parser.print_help()


### PR DESCRIPTION
This cleans up the torchchat CLI to output the full help options and others. Some testing that can be done:

```
% python torchchat.py

usage: torchchat [-h] [--chat] [--gui] [--seed SEED] [--prompt PROMPT] [--tiktoken] [--is-chat-model] [--num-samples NUM_SAMPLES] [--max-new-tokens MAX_NEW_TOKENS]
                 [--top-k TOP_K] [--temperature TEMPERATURE] [--compile] [--compile-prefill] [--profile PROFILE] [--speculate-k SPECULATE_K]
                 [--draft-checkpoint-path DRAFT_CHECKPOINT_PATH] [--checkpoint-path CHECKPOINT_PATH] [--checkpoint-dir CHECKPOINT_DIR] [--params-path PARAMS_PATH]
                 [--gguf-path GGUF_PATH] [--tokenizer-path TOKENIZER_PATH] [--output-pte-path OUTPUT_PTE_PATH] [--output-dso-path OUTPUT_DSO_PATH] [--dso-path DSO_PATH]
                 [--pte-path PTE_PATH] [-d DTYPE] [-v] [--quantize QUANTIZE] [--params-table PARAMS_TABLE] [--device DEVICE] [--tasks TASKS [TASKS ...]] [--limit LIMIT]
                 [--max-seq-length MAX_SEQ_LENGTH]
                 {chat,browser,download,generate,eval,export} ...

Welcome to the torchchat CLI!

positional arguments:
  {chat,browser,download,generate,eval,export}
                        The specific command to run

optional arguments:
  -h, --help            show this help message and exit
  --chat                Whether to start an interactive chat session
...
```

```
% python torchchat.py chat
RuntimeError: need to specified a valid checkpoint path, checkpoint dir, gguf path, DSO path, or PTE path
```
I'd like the above to be cleaner.

```
% python torchchat.py browser
 * Serving Flask app 'chat_in_browser:create_app("--chat")'
 * Debug mode: off
WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
 * Running on http://127.0.0.1:5000
Press CTRL+C to quit
usage: generate.py [-h]
generate.py: error: unrecognized arguments: --chat
```
We probably need to have this error out to require a path

```
% python torchchat.py download
Traceback (most recent call last):
  File "torchchat.py", line 84, in <module>
    check_args(args, "download")
  File "/Users/orionr/local/torchchat/cli.py", line 27, in check_args
    raise RuntimeError(
RuntimeError: command download requires a valid model name or Hugging Face model path
```

```
% python torchchat.py generate
Traceback (most recent call last):
  File "torchchat.py", line 92, in <module>
    generate_main(args)
  File "/Users/orionr/local/torchchat/generate.py", line 546, in main
    builder_args = BuilderArgs.from_args(args)
  File "/Users/orionr/local/torchchat/build/builder.py", line 90, in from_args
    return cls(
  File "<string>", line 16, in __init__
  File "/Users/orionr/local/torchchat/build/builder.py", line 50, in __post_init__
    raise RuntimeError(
RuntimeError: need to specified a valid checkpoint path, checkpoint dir, gguf path, DSO path, or PTE path
```

```
% python torchchat.py eval
Note: NumExpr detected 16 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 8.
NumExpr defaulting to 8 threads.
PyTorch version 2.2.2 available.
```

```
% python torchchat.py export
Traceback (most recent call last):
  File "torchchat.py", line 101, in <module>
    export_main(args)
  File "/Users/orionr/local/torchchat/export.py", line 44, in main
    builder_args = BuilderArgs.from_args(args)
  File "/Users/orionr/local/torchchat/build/builder.py", line 90, in from_args
    return cls(
  File "<string>", line 16, in __init__
  File "/Users/orionr/local/torchchat/build/builder.py", line 50, in __post_init__
    raise RuntimeError(
RuntimeError: need to specified a valid checkpoint path, checkpoint dir, gguf path, DSO path, or PTE path
```