### PR TITLE
Fix gpqt for AOTI on cuda and Re-enable int4 on CI

### DIFF
--- a/.ci/scripts/validate.sh
+++ b/.ci/scripts/validate.sh
@@ -177,15 +177,12 @@ function generate_aoti_model_output() {
         echo "******************************************"
         echo "******** INT4 group-wise quantized *******"
         echo "******************************************"
-        if [ $(uname -s) == "Linux" ]; then
-            echo "Skipping INT4 groupwise quantization because AOTI fails"
-        else
-            python3 -W ignore export.py --dtype ${DTYPE} --quant '{"linear:int4" : {"groupsize": 32}}' --checkpoint-path "$CHECKPOINT_PATH" --output-dso-path ${MODEL_DIR}/${MODEL_NAME}.so --device "$TARGET_DEVICE" || exit 1
+        if [ "$TARGET_DEVICE" == "cuda" ]; then
+            python3 -W ignore export.py --dtype ${DTYPE} --quant '{"linear:int4-gptq" : {"groupsize": 32}}' --checkpoint-path "$CHECKPOINT_PATH" --output-dso-path ${MODEL_DIR}/${MODEL_NAME}.so --device "$TARGET_DEVICE" || exit 1
             python3 -W ignore generate.py --dtype ${DTYPE} --checkpoint-path "$CHECKPOINT_PATH" --temperature 0 --dso-path ${MODEL_DIR}/${MODEL_NAME}.so --device "$TARGET_DEVICE" > "$MODEL_DIR/output_aoti" || exit 1
             cat "$MODEL_DIR/output_aoti"
-
-            if [ "$TARGET_DEVICE" == "cuda" ]; then
-                python3 -W ignore export.py --dtype ${DTYPE} --quant '{"linear:int4-gptq" : {"groupsize": 32}}' --checkpoint-path "$CHECKPOINT_PATH" --output-dso-path ${MODEL_DIR}/${MODEL_NAME}.so --device "$TARGET_DEVICE" || exit 1
+            if [ "$DTYPE" != "float16" ]; then
+                python3 -W ignore export.py --dtype ${DTYPE} --quant '{"linear:int4" : {"groupsize": 32}}' --checkpoint-path "$CHECKPOINT_PATH" --output-dso-path ${MODEL_DIR}/${MODEL_NAME}.so --device "$TARGET_DEVICE" || exit 1
                 python3 -W ignore generate.py --dtype ${DTYPE} --checkpoint-path "$CHECKPOINT_PATH" --temperature 0 --dso-path ${MODEL_DIR}/${MODEL_NAME}.so --device "$TARGET_DEVICE" > "$MODEL_DIR/output_aoti" || exit 1
                 cat "$MODEL_DIR/output_aoti"
             fi

--- a/export_aoti.py
+++ b/export_aoti.py
@@ -24,6 +24,7 @@ def export_model(model: nn.Module, device, output_path, args=None):
     # Specify that the first dimension of each input is that batch size
     dynamic_shapes = {"idx": {1: seq}, "input_pos": {0: seq}}
 
+    model.to(device)
     so = torch._export.aot_compile(
         model,
         args=input,


### PR DESCRIPTION
[Placeholder] Whenever the torch nightly is ready, re-enable the test in CI to avoid regression.