### PR TITLE
[Llama3] Support Llama3 download from Hugging Face

### DIFF
--- a/build/model.py
+++ b/build/model.py
@@ -42,7 +42,7 @@ class ModelArgs:
     multiple_of: int = 256
     ffn_dim_multiplier: Optional[int] = None
     use_tiktoken: Optional[bool] = None
-    
+
     def __post_init__(self):
         if self.n_local_heads == -1:
             self.n_local_heads = self.n_heads
@@ -60,7 +60,7 @@ class ModelArgs:
         if isinstance(self.use_tiktoken, str):
             self.use_tiktoken = (self.use_tiktoken == "True")
 
-            
+
     @classmethod
     def from_params(cls, params_path):
         replace = [("rope_theta", "rope_base"), ("n_kv_heads", "n_local_heads")]
@@ -85,19 +85,19 @@ class ModelArgs:
 
     @classmethod
     def from_name(cls, name: str):
-        print(f"name {name}")
+        print(f"Name {name}")
         json_path=f"{config_dir}/{name}.json"
         if Path(json_path).is_file():
             return ModelArgs.from_params(json_path)
 
         known_model_params = [config.replace(".json", "") for config in os.listdir(config_dir)]
 
-        print(f"known configs: {known_model_params}")
-        # fuzzy search
+        # Fuzzy search by name (e.g. "7B" and "Mistral-7B")
+        print(f"Known configs: {known_model_params}")
         config = [
             config
             for config in known_model_params
-            if config.replace in str(name).upper() or config in str(name)
+            if config in str(name).upper() or config in str(name)
         ]
 
         # We may have two or more configs matched (e.g. "7B" and "Mistral-7B"). Find the best config match,

--- a/config/data/models.json
+++ b/config/data/models.json
@@ -1,11 +1,16 @@
 {
+    "meta-llama/Meta-Llama-3-8B-Instruct": {
+        "aliases": ["llama3", "llama3-8b"],
+        "distribution_channel": "HuggingFaceSnapshot",
+        "distribution_path": "meta-llama/Meta-Llama-3-8B-Instruct"
+    },
     "meta-llama/Llama-2-7b-chat-hf": {
         "aliases": ["llama2", "llama2-7b"],
         "distribution_channel": "HuggingFaceSnapshot",
         "distribution_path": "meta-llama/Llama-2-7b-chat-hf"
     },
     "mistralai/Mistral-7B-Instruct-v0.2": {
-        "aliases": ["mistral-7b-instruct"],
+        "aliases": ["mistral-7b", "mistral-7b-instruct"],
         "distribution_channel": "HuggingFaceSnapshot",
         "distribution_path": "mistralai/Mistral-7B-Instruct-v0.2"
     },

--- a/download.py
+++ b/download.py
@@ -26,7 +26,7 @@ def _download_and_convert_hf_snapshot(
     from huggingface_hub import snapshot_download
 
     # Download and store the HF model artifacts.
-    print(f"Downloading {model} from HuggingFace...")
+    print(f"Downloading {model} from Hugging Face...")
     try:
         snapshot_download(
             model,


### PR DESCRIPTION
The Llama 3 instruct files downloaded from https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct have a different directory structure than what we see with Llama 2. It is much simpler, with a unified `.pth` file and a tokenizer next to it.

You can test this out by running

```
python torchchat.py download llama3
```

Or just trying to run it with

```
python torchchat.py chat llama3 --device=cpu --dtype=fp16 --tiktoken
```

I'd like to make it so you don't need to specify the `--tiktoken` flag above (we'd just know based on config) but need to talk with @larryliu0820 about that later and maybe get his help.
