### PR TITLE
Add additional supported models to config/data/models.json

### DIFF
--- a/build/known_model_params/stories42M.json
+++ b/build/known_model_params/stories42M.json
@@ -1,0 +1,1 @@
+{"n_layers": 8, "n_heads": 8, "dim": 512, "hidden_dim": 1376}

--- a/build/model.py
+++ b/build/model.py
@@ -112,7 +112,6 @@ class ModelArgs:
         return ModelArgs.from_params(config_path / f"{config[0]}.json")
 
 
-
 class KVCache(nn.Module):
     def __init__(self, max_batch_size, max_seq_length, n_heads, head_dim, dtype=None):
         super().__init__()

--- a/config/data/models.json
+++ b/config/data/models.json
@@ -1,13 +1,38 @@
 {
-    "meta-llama/Meta-Llama-3-8B-Instruct": {
-        "aliases": ["llama3", "llama3-8b"],
-        "distribution_channel": "HuggingFaceSnapshot",
-        "distribution_path": "meta-llama/Meta-Llama-3-8B-Instruct"
-    },
-    "meta-llama/Llama-2-7b-chat-hf": {
+    "meta-llama/Llama-2-7b-hf": {
         "aliases": ["llama2", "llama2-7b"],
         "distribution_channel": "HuggingFaceSnapshot",
-        "distribution_path": "meta-llama/Llama-2-7b-chat-hf"
+        "distribution_path": "meta-llama/Llama-2-7b-hf",
+        "transformer_params_key": "7B"
+    },
+    "meta-llama/Llama-2-7b-chat-hf": {
+        "aliases": ["llama2-chat", "llama2-7b-chat"],
+        "distribution_channel": "HuggingFaceSnapshot",
+        "distribution_path": "meta-llama/Llama-2-7b-chat-hf",
+        "transformer_params_key": "7B"
+    },
+    "meta-llama/Llama-2-13b-chat-hf": {
+        "aliases": ["llama2-13b-chat"],
+        "distribution_channel": "HuggingFaceSnapshot",
+        "distribution_path": "meta-llama/Llama-2-13b-chat-hf",
+        "transformer_params_key": "13B"
+    },
+    "meta-llama/Llama-2-70b-chat-hf": {
+        "aliases": ["llama2-70b-chat"],
+        "distribution_channel": "HuggingFaceSnapshot",
+        "distribution_path": "meta-llama/Llama-2-70b-chat-hf",
+        "transformer_params_key": "70B"
+    },
+    "meta-llama/Meta-Llama-3-8B": {
+        "aliases": ["llama3"],
+        "distribution_channel": "HuggingFaceSnapshot",
+        "distribution_path": "meta-llama/Meta-Llama-3-8B"
+    },
+    "meta-llama/Meta-Llama-3-8B-Instruct": {
+        "aliases": ["llama3-chat", "llama3-instruct"],
+        "distribution_channel": "HuggingFaceSnapshot",
+        "distribution_path": "meta-llama/Meta-Llama-3-8B-Instruct",
+        "transformer_params_key": "Meta-Llama-3-8B"
     },
     "meta-llama/CodeLlama-7b-Python-hf": {
         "aliases": ["codellama", "codellama-7b"],
@@ -17,7 +42,14 @@
     "mistralai/Mistral-7B-Instruct-v0.2": {
         "aliases": ["mistral-7b", "mistral-7b-instruct"],
         "distribution_channel": "HuggingFaceSnapshot",
-        "distribution_path": "mistralai/Mistral-7B-Instruct-v0.2"
+        "distribution_path": "mistralai/Mistral-7B-Instruct-v0.2",
+        "transformer_params_key": "Mistral-7B"
+    },
+    "openlm-research/open_llama_7b": {
+        "aliases": ["open-llama", "open-llama-7b"],
+        "distribution_channel": "HuggingFaceSnapshot",
+        "distribution_path": "openlm-research/open_llama_7b",
+        "transformer_params_key": "7B"
     },
     "stories15M": {
         "distribution_channel": "DirectDownload",
@@ -26,6 +58,14 @@
             "https://github.com/karpathy/llama2.c/raw/master/tokenizer.model"
         ],
         "checkpoint_file": "stories15M.pt"
+    },
+    "stories42M": {
+        "distribution_channel": "DirectDownload",
+        "distribution_path": [
+            "https://huggingface.co/karpathy/tinyllamas/resolve/main/stories42M.pt",
+            "https://github.com/karpathy/llama2.c/raw/master/tokenizer.model"
+        ],
+        "checkpoint_file": "stories42M.pt"
     },
     "stories110M": {
         "distribution_channel": "DirectDownload",

--- a/config/model_config.py
+++ b/config/model_config.py
@@ -44,6 +44,8 @@ class ModelConfig:
         default=ModelDistributionChannel.HuggingFaceSnapshot
     )
     checkpoint_file: str = field(default="model.pth")
+    tokenizer_file: str = field(default="tokenizer.model")
+    transformer_params_key: str = field(default=None)
 
 
 # Keys are stored in lowercase.


### PR DESCRIPTION
Add more llama variants and stories42M to models.json. Fix regressions from recent transformer config changes. Add convert and tokenizer fields to ModelConfig.

I also added non-chat variants of llama2 and llama3. I've listed non chat variants with aliases llama2 and llama3, while the chat variants are llama2-chat and llama3-chat. Feel free to discuss this or push back. My potential concern is that users may actually always want the chat versions, so maybe llama2/llama3 should point to chat and the non-chat variants should be called something else?

Test Plan:
```
python torchchat.py generate stories42M
python torchchat.py generate llama2-chat --dtype fp16 --max-new-tokens 20
python torchchat.py generate llama2 --dtype fp16 --max-new-tokens 20
python torchchat.py generate llama3 --dtype fp16 --max-new-tokens 20 --tiktoken
python torchchat.py generate llama3-chat --dtype fp16 --max-new-tokens 20 --tiktoken
```