### PR TITLE
Keep default llama3 and llama2 as instruct/chat tunings respectively

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,11 @@ These are the supported models
 | Model | Mobile Friendly | Notes |
 |------------------|---|---------------------|
 |[meta-llama/Meta-Llama-3-8B-Instruct](https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct)|✅||
+|[meta-llama/Meta-Llama-3-8B](https://huggingface.co/meta-llama/Meta-Llama-3-8B)|✅||
 |[meta-llama/Llama-2-7b-chat-hf](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf)|✅||
 |[meta-llama/Llama-2-13b-chat-hf](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf)|||
 |[meta-llama/Llama-2-70b-chat-hf](https://huggingface.co/meta-llama/Llama-2-70b-chat-hf)|||
+|[meta-llama/Llama-2-7b-hf](https://huggingface.co/meta-llama/Llama-2-7b-hf)|✅||
 |[meta-llama/CodeLlama-7b-Python-hf](https://huggingface.co/meta-llama/CodeLlama-7b-Python-hf)|✅||
 |[meta-llama/CodeLlama-34b-Python-hf](https://huggingface.co/meta-llama/CodeLlama-34b-Python-hf)|✅||
 |[mistralai/Mistral-7B-v0.1](https://huggingface.co/mistralai/Mistral-7B-v0.1)|✅||

--- a/config/data/models.json
+++ b/config/data/models.json
@@ -1,12 +1,12 @@
 {
     "meta-llama/Llama-2-7b-hf": {
-        "aliases": ["llama2", "llama2-7b"],
+        "aliases": ["llama2-base", "llama2-7b"],
         "distribution_channel": "HuggingFaceSnapshot",
         "distribution_path": "meta-llama/Llama-2-7b-hf",
         "transformer_params_key": "7B"
     },
     "meta-llama/Llama-2-7b-chat-hf": {
-        "aliases": ["llama2-chat", "llama2-7b-chat"],
+        "aliases": ["llama2", "llama2-chat", "llama2-7b-chat"],
         "distribution_channel": "HuggingFaceSnapshot",
         "distribution_path": "meta-llama/Llama-2-7b-chat-hf",
         "transformer_params_key": "7B"
@@ -24,12 +24,12 @@
         "transformer_params_key": "70B"
     },
     "meta-llama/Meta-Llama-3-8B": {
-        "aliases": ["llama3"],
+        "aliases": ["llama3-base"],
         "distribution_channel": "HuggingFaceSnapshot",
         "distribution_path": "meta-llama/Meta-Llama-3-8B"
     },
     "meta-llama/Meta-Llama-3-8B-Instruct": {
-        "aliases": ["llama3-chat", "llama3-instruct"],
+        "aliases": ["llama3", "llama3-chat", "llama3-instruct"],
         "distribution_channel": "HuggingFaceSnapshot",
         "distribution_path": "meta-llama/Meta-Llama-3-8B-Instruct",
         "transformer_params_key": "Meta-Llama-3-8B"
@@ -40,7 +40,7 @@
         "distribution_path": "meta-llama/CodeLlama-7b-Python-hf"
     },
     "mistralai/Mistral-7B-Instruct-v0.2": {
-        "aliases": ["mistral-7b", "mistral-7b-instruct"],
+        "aliases": ["mistral", "mistral-7b", "mistral-7b-instruct"],
         "distribution_channel": "HuggingFaceSnapshot",
         "distribution_path": "mistralai/Mistral-7B-Instruct-v0.2",
         "transformer_params_key": "Mistral-7B"


### PR DESCRIPTION
Great to have the new models supported by download! However, we want to still keep the same Llama 3 and 2 defaults with instruct and chat tunings. Otherwise users will need to specify a longer name in the README and 9 out of 10 times they are going to want to use these versions anyway.

Also added new support to the README

cc @GregoryComer @mikekgfb 