### PR TITLE
Link to acknowledgements and license from the README and callout models

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, Michael Gschwind
+Copyright (c) 2024 Meta
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -217,3 +217,11 @@ Install [ExecuTorch](https://pytorch.org/executorch/stable/getting-started-setup
 Read the [iOS documentation](docs/iOS.md) for more details on iOS.
 
 Read the [Android documentation](docs/Android.md) for more details on Android.
+
+## Acknowledgements
+Thank you to the [community](docs/ACKNOWLEDGEMENTS.md) for all the awesome libraries and tools
+you've built around local LLM inference.
+
+## License
+Torchchat is released under the [BSD 3 license](LICENSE). However you may have other legal obligations
+that govern your use of content, such as the terms of service for third-party models.


### PR DESCRIPTION
We should link to the acknowledgements and license from the README, especially since this is the same as torchtune and others do. Also fixed the LICENSE to reference Meta not individual.

Second half of https://github.com/pytorch/torchchat/issues/333