### PR TITLE
Use shutil.move instead of os.rename for moving downloaded model artifacts

### DIFF
--- a/download.py
+++ b/download.py
@@ -93,7 +93,7 @@ def download_and_convert(
         # overwriting if necessary.
         if os.path.isdir(model_dir):
             shutil.rmtree(model_dir)
-        os.rename(temp_dir, model_dir)
+        shutil.move(temp_dir, model_dir)
 
     finally:
         if os.path.isdir(temp_dir):


### PR DESCRIPTION
This fixes an issue where downloaded models are not being properly copied to the final location. I have not been able to reproduce this locally, but this change does resolve the issue for people that see it. While I want to better understand the issue. shutil.move should be more robust.