### PR TITLE
ci: Switch 32-core-ubuntu --> linux.4xlarge

### DIFF
--- a/.ci/scripts/gather_test_models.py
+++ b/.ci/scripts/gather_test_models.py
@@ -23,7 +23,7 @@ MODEL_REPOS = {
 
 JOB_RUNNERS = {
     "cpu": {
-        "32-core-ubuntu": "x86_64",
+        "linux.4xlarge": "x86_64",
         # "macos-12": "x86_64", # not working for complie and ExecuTorch yet
         "macos-14": "aarch64",
     },


### PR DESCRIPTION
Github hosted runners seeemed to be experiencing elevated queuing so let's switch to our own runners to see if this works