### PR TITLE
change test to use setup recommended in readme

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -182,7 +182,7 @@ jobs:
   test-tinystories-executorch:
     strategy:
       matrix:
-        runner: [16-core-ubuntu]
+        runner: [16-core-ubuntu, macos-14-xlarge]
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout repo


### PR DESCRIPTION
This changes CI test to use recommended install method in README.md.

It also adds a mac-os test, which I just noticed we didn't have before.  I recently see ET generate failing on my M1 mac with "Missing operator: [12] llama::sdpa_with_kv_cache.out" (P1221271760).