### PR TITLE
Move model download to check_args so generate.py also downloads models

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -16,16 +16,12 @@ from download import download_and_convert, is_model_downloaded
 default_device = "cpu"  # 'cuda' if torch.cuda.is_available() else 'cpu'
 
 
-def check_args(args, name: str) -> None:
-    pass
-
-
 # Handle CLI arguments that are common to a majority of subcommands.
-def handle_common_args(args) -> None:
+def check_args(args, name: str) -> None:
     # Handle model download. Skip this for download, since it has slightly
     # different semantics.
     if (
-        args.command != "download"
+        name != "download"
         and args.model
         and not is_model_downloaded(args.model, args.model_directory)
     ):

--- a/torchchat.py
+++ b/torchchat.py
@@ -19,7 +19,6 @@ from cli import (
     add_arguments_for_generate,
     arg_init,
     check_args,
-    handle_common_args,
 )
 
 default_device = "cpu"
@@ -97,8 +96,6 @@ if __name__ == "__main__":
     logging.basicConfig(
         format="%(message)s", level=logging.DEBUG if args.verbose else logging.INFO
     )
-
-    handle_common_args(args)
 
     if args.command == "chat":
         # enable "chat"


### PR DESCRIPTION
This was failing if you don't have `.model-artifacts/stories15M/` downloaded. To repro:

```
rm -rf .model-artifacts/stories15M/
python3 torchchat.py browser stories15M --temperature 0 --num-samples 10
# fails
python3 generate.py stories15M
# minimal repro fails
```

And, with the fix, succeeds. Please confirm this, though!
