### PR TITLE
Add list and remove commands

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -364,7 +364,10 @@ jobs:
       - name: Test download
         run: |
 
+          python torchchat.py list
+          python torchchat.py download stories15m
           python torchchat.py generate stories15M
+          python torchchat.py remove stories15m
 
   test-tinystories-eager:
     strategy:

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ HuggingFace.
 python3 torchchat.py download llama3
 ```
 
+View available models with `python3 torchchat.py list`. You can also remove downloaded models
+with `python3 torchchat.py remove llama3`.
+
 ## What can you do with torchchat?
 
 * Run models via PyTorch / Python:

--- a/cli.py
+++ b/cli.py
@@ -21,7 +21,7 @@ def check_args(args, name: str) -> None:
     # Handle model download. Skip this for download, since it has slightly
     # different semantics.
     if (
-        name != "download"
+        name not in ["download", "list", "remove"]
         and args.model
         and not is_model_downloaded(args.model, args.model_directory)
     ):
@@ -61,6 +61,13 @@ def add_arguments_for_export(parser):
     # Only export specific options should be here
     _add_arguments_common(parser)
 
+def add_arguments_for_list(parser):
+    # Only list specific options should be here
+    _add_arguments_common(parser)
+
+def add_arguments_for_remove(parser):
+    # Only remove specific options should be here
+    _add_arguments_common(parser)
 
 def _add_arguments_common(parser):
     # Model specification. TODO Simplify this.

--- a/config/model_config.py
+++ b/config/model_config.py
@@ -53,31 +53,35 @@ model_aliases: Dict[str, str] = None
 model_configs: Dict[str, ModelConfig] = None
 
 
-def resolve_model_config(model: str) -> ModelConfig:
+def load_model_configs() -> Dict[str, ModelConfig]:
     global model_aliases
     global model_configs
 
-    model = model.lower()
+    model_aliases = {}
+    model_configs = {}
 
+    with open(
+        Path(__file__).parent.parent / "config" / "data" / "models.json", "r"
+    ) as f:
+        model_config_dict = json.load(f)
+
+    for key, value in model_config_dict.items():
+        config = ModelConfig(**value)
+        config.name = key
+
+        key = key.lower()
+        model_configs[key] = config
+
+        for alias in config.aliases:
+            model_aliases[alias.lower()] = key
+
+    return model_configs
+
+def resolve_model_config(model: str) -> ModelConfig:
+    model = model.lower()
     # Lazy load model config from JSON.
     if not model_configs:
-        model_aliases = {}
-        model_configs = {}
-
-        with open(
-            Path(__file__).parent.parent / "config" / "data" / "models.json", "r"
-        ) as f:
-            model_config_dict = json.load(f)
-
-        for key, value in model_config_dict.items():
-            config = ModelConfig(**value)
-            config.name = key
-
-            key = key.lower()
-            model_configs[key] = config
-
-            for alias in config.aliases:
-                model_aliases[alias.lower()] = key
+        load_model_configs()
 
     if model in model_aliases:
         model = model_aliases[model]

--- a/torchchat.py
+++ b/torchchat.py
@@ -17,6 +17,8 @@ from cli import (
     add_arguments_for_eval,
     add_arguments_for_export,
     add_arguments_for_generate,
+    add_arguments_for_list,
+    add_arguments_for_remove,
     arg_init,
     check_args,
 )
@@ -75,6 +77,18 @@ if __name__ == "__main__":
         help="Export a model for AOT Inductor or ExecuTorch",
     )
     add_arguments_for_export(parser_export)
+
+    parser_list = subparsers.add_parser(
+        "list",
+        help="List supported models",
+    )
+    add_arguments_for_list(parser_list)
+
+    parser_remove = subparsers.add_parser(
+        "remove",
+        help="Remove downloaded model artifacts",
+    )
+    add_arguments_for_remove(parser_remove)
 
     # Move all flags to the front of sys.argv since we don't
     # want to use the subparser syntax
@@ -143,7 +157,7 @@ if __name__ == "__main__":
         subprocess.run(command)
     elif args.command == "download":
         check_args(args, "download")
-        from download import main as download_main
+        from download import download_main
 
         download_main(args)
     elif args.command == "generate":
@@ -160,5 +174,15 @@ if __name__ == "__main__":
         from export import main as export_main
 
         export_main(args)
+    elif args.command == "list":
+        check_args(args, "list")
+        from download import list_main
+
+        list_main(args)
+    elif args.command == "remove":
+        check_args(args, "remove")
+        from download import remove_main
+
+        remove_main(args)
     else:
         parser.print_help()


### PR DESCRIPTION
Add two new commands:
 list: Displays a list of available models, along with aliases and whether or not they have been downloaded.
 remove: Deletes downloaded artifacts for a model.

Feel free to provide feedback on the list command output (see below). There might be a better way to display this information. I originally had each model named the same as the HF path to resolve the transformer params, but I can decouple that. Maybe we name each model according to its current alias? Though I feel like the current way is fine, too.

Example list output:
```
Model                                Aliases                                   Downloaded
------------------------------------ ----------------------------------------- -----------
meta-llama/llama-2-7b-hf             llama2-base, llama2-7b
meta-llama/llama-2-7b-chat-hf        llama2, llama2-chat, llama2-7b-chat
meta-llama/llama-2-13b-chat-hf       llama2-13b-chat
meta-llama/llama-2-70b-chat-hf       llama2-70b-chat
meta-llama/meta-llama-3-8b           llama3-base
meta-llama/meta-llama-3-8b-instruct  llama3, llama3-chat, llama3-instruct      Yes
meta-llama/codellama-7b-python-hf    codellama, codellama-7b
mistralai/mistral-7b-instruct-v0.2   mistral, mistral-7b, mistral-7b-instruct
openlm-research/open_llama_7b        open-llama, open-llama-7b
stories15m
stories42m
stories110m
```

Test Plan:
```
# Starting with stories 15m downloaded, stories42m not downloaded.
python torchchat.py list

python torchchat.py remove stories42m
# Reports no downloaded model artifacts for stories42m

python torchchat.py remove stories15m
python torchchat.py list
python torchchat.py generate stories15m
python torchchat.py list
```