### PR TITLE
Add android cross compilation for et runner

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -841,3 +841,28 @@ jobs:
           cat ${PWD}/output_aoti
 
           echo "Tests complete."
+
+  test-build-runner-et-android:
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    with:
+      runner: linux.4xlarge
+      script: |
+          uname -a
+          if [ $(uname -s) == Darwin ]; then
+            sysctl machdep.cpu.brand_string
+            sysctl machdep.cpu.core_count
+          fi
+          git submodule sync
+          git submodule update --init
+          echo "Intalling pip packages"
+          pip install cmake --upgrade
+          cmake --version
+          pip install -r requirements.txt
+          export TORCHCHAT_ROOT=${PWD}
+          pushd /tmp
+          wget https://dl.google.com/android/repository/android-ndk-r26c-linux.zip
+          unzip android-ndk-r26c-linux.zip
+          popd
+          export ANDROID_NDK=/tmp/android-ndk-r26c
+          ./runner/build_android.sh
+          echo "Tests complete."

--- a/runner/build_android.sh
+++ b/runner/build_android.sh
@@ -18,9 +18,6 @@ else
   echo "ANDROID_NDK set to ${ANDROID_NDK}"
 fi
 
-export CMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake
-export ANDROID_ABI=arm64-v8a
-export ANDROID_PLATFORM=android-23
 export ET_BUILD_DIR="et-build-android"
 export CMAKE_OUT_DIR="cmake-out-android"
 export EXECUTORCH_BUILD_CUSTOM_OPS_AOT="OFF"
@@ -37,6 +34,13 @@ build_runner_et() {
 }
 
 find_cmake_prefix_path
+install_pip_dependencies
 clone_executorch
+export ENABLE_ET_PYBIND=false
+install_executorch_python_libs $ENABLE_ET_PYBIND
+
+export CMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake
+export ANDROID_ABI=arm64-v8a
+export ANDROID_PLATFORM=android-23
 install_executorch
 build_runner_et


### PR DESCRIPTION
Summary:
Download android ndk r26c
Use that to run build_android.sh

Test Plan:
CI

Reviewers:

Subscribers:

Tasks:

Tags: