### PR TITLE
Recognize instruct models as chat

### DIFF
--- a/build/builder.py
+++ b/build/builder.py
@@ -94,7 +94,7 @@ class BuilderArgs:
             is_chat_model = True
         else:
             for path in [
-                args.checkpoint_path,
+                checkpoint_path,
                 checkpoint_dir,
                 args.dso_path,
                 args.pte_path,
@@ -104,8 +104,11 @@ class BuilderArgs:
                     path = str(path)
                     if path.endswith("/"):
                         path = path[:-1]
-                    path_basename = os.path.basename(path)
-                    if "chat" in path_basename:
+                    if os.path.isfile(path):
+                        path = os.path.dirname(path)
+
+                    path_basename = os.path.basename(path).lower()
+                    if "chat" in path_basename or "instruct" in path_basename:
                         is_chat_model = True
 
         return cls(
@@ -222,7 +225,7 @@ class TokenizerArgs:
             t=None,
         )
 
-    
+
 def _initialize_tokenizer(tokenizer_args: TokenizerArgs):
     return tokenizer_args.t
 


### PR DESCRIPTION
Torchchat currently treats models containing "chat" in the name as chat models. This change also checks for "instruct". If present, it assumes the model is chat-capable. Also note that I updated the logic to check the directory name when checking for chat/instruct in a checkpoint_path, instead of the file name. Most of the time, the files are named model.pt or consolidated.0.pt or similar. However, there is a potential case where someone has a standalone model file named llama3-chat or something. Though they should probably just pass the named arg if they're using their own model file.

The motivation for this change is to detect llama3-instruct as chat capable.

Test Plan:
```
# Expect no warning
python torchchat.py chat llama3

# Expect warning
python torchchat.py chat stories15m 
```