### PR TITLE
Remove unused function resolve_model_name - fixes lint

### DIFF
--- a/build/builder.py
+++ b/build/builder.py
@@ -222,7 +222,7 @@ class TokenizerArgs:
             t=None,
         )
 
-    
+
 def _initialize_tokenizer(tokenizer_args: TokenizerArgs):
     return tokenizer_args.t
 
@@ -415,11 +415,3 @@ def _initialize_model(
 
 def tokenizer_setting_to_name(tiktoken: bool = False) -> str:
     return "TikToken" if tiktoken else "SentencePiece"
-
-
-def resolve_model_name(model: str) -> str:
-    # If the provided model name is an alias, retrieve the full path.
-    if model in model_aliases:
-        return model_aliases[model]
-    else:
-        return model


### PR DESCRIPTION
Fix https://github.com/pytorch/torchchat/issues/334 by removing unused function. This was superseded by resolve_model_config. Confirmed unused by greping for resolve_model_name.