### PR TITLE
Add download entries for remaining models, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,24 +68,33 @@ python3 torchchat.py download llama3
   * [Running exported executorch file on iOS or Android](#run-mobile)
 
 ## Models
-These are the supported models
-| Model | Mobile Friendly | Notes |
-|------------------|---|---------------------|
-|[meta-llama/Meta-Llama-3-8B-Instruct](https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct)|✅||
-|[meta-llama/Meta-Llama-3-8B](https://huggingface.co/meta-llama/Meta-Llama-3-8B)|✅||
-|[meta-llama/Llama-2-7b-chat-hf](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf)|✅||
-|[meta-llama/Llama-2-13b-chat-hf](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf)|||
-|[meta-llama/Llama-2-70b-chat-hf](https://huggingface.co/meta-llama/Llama-2-70b-chat-hf)|||
-|[meta-llama/Llama-2-7b-hf](https://huggingface.co/meta-llama/Llama-2-7b-hf)|✅||
-|[meta-llama/CodeLlama-7b-Python-hf](https://huggingface.co/meta-llama/CodeLlama-7b-Python-hf)|✅||
-|[meta-llama/CodeLlama-34b-Python-hf](https://huggingface.co/meta-llama/CodeLlama-34b-Python-hf)|✅||
-|[mistralai/Mistral-7B-v0.1](https://huggingface.co/mistralai/Mistral-7B-v0.1)|✅||
-|[mistralai/Mistral-7B-Instruct-v0.1](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.1)|✅||
-|[mistralai/Mistral-7B-Instruct-v0.2](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2)|✅||
-|[tinyllamas/stories15M](https://huggingface.co/karpathy/tinyllamas/tree/main)|✅||
-|[tinyllamas/stories42M](https://huggingface.co/karpathy/tinyllamas/tree/main)|✅||
-|[tinyllamas/stories110M](https://huggingface.co/karpathy/tinyllamas/tree/main)|✅||
-|[openlm-research/open_llama_7b](https://huggingface.co/karpathy/tinyllamas/tree/main)|✅||
+
+The following models have been tested on torchchat and support downloading weights from HuggingFace with a HuggingFace account (see [Download Weights](#download-weights)).
+
+| Model | Alias | Mobile Friendly | Notes |
+|------------------|-------|---|---------------------|
+|[meta-llama/Meta-Llama-3-8B-Instruct](https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct)|llama3|✅||
+|[meta-llama/Meta-Llama-3-8B](https://huggingface.co/meta-llama/Meta-Llama-3-8B)|llama3-base|✅||
+|[meta-llama/Llama-2-7b-chat-hf](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf)|llama2|✅||
+|[meta-llama/Llama-2-13b-chat-hf](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf)|llama2-13b-chat|||
+|[meta-llama/Llama-2-70b-chat-hf](https://huggingface.co/meta-llama/Llama-2-70b-chat-hf)|llama2-70b-chat|||
+|[meta-llama/Llama-2-7b-hf](https://huggingface.co/meta-llama/Llama-2-7b-hf)|llama2-base|✅||
+|[meta-llama/CodeLlama-7b-Python-hf](https://huggingface.co/meta-llama/CodeLlama-7b-Python-hf)|codellama-7b|✅||
+|[meta-llama/CodeLlama-34b-Python-hf](https://huggingface.co/meta-llama/CodeLlama-34b-Python-hf)|codellama-34b|✅||
+|[mistralai/Mistral-7B-v0.1](https://huggingface.co/mistralai/Mistral-7B-v0.1)|mistral-7b|✅||
+|[mistralai/Mistral-7B-Instruct-v0.1](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.1)|mistral-7b-instruct-v1|✅||
+|[mistralai/Mistral-7B-Instruct-v0.2](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2)|mistral-7b-instruct-v2|✅||
+|[tinyllamas/stories15M](https://huggingface.co/karpathy/tinyllamas/tree/main)|stories15M|✅||
+|[tinyllamas/stories42M](https://huggingface.co/karpathy/tinyllamas/tree/main)|stories42M|✅||
+|[tinyllamas/stories110M](https://huggingface.co/karpathy/tinyllamas/tree/main)|stories110M|✅||
+|[openlm-research/open_llama_7b](https://huggingface.co/openlm-research/open_llama_7b/tree/main)|open-llama-7b|✅||
+
+Supported models can be used for chat, generation, and export by passing the full name or alias:
+```
+python3 torchchat.py chat llama3
+```
+
+Run `python3 torchchat.py list` to view the list of supported models from the command line, as well as see which models are locally downloaded.
 
 See the [documentation on GGUF](docs/GGUF.md) to learn how to use GGUF files.
 

--- a/config/data/models.json
+++ b/config/data/models.json
@@ -39,8 +39,25 @@
         "distribution_channel": "HuggingFaceSnapshot",
         "distribution_path": "meta-llama/CodeLlama-7b-Python-hf"
     },
+    "meta-llama/CodeLlama-34b-Python-hf": {
+        "aliases": ["codellama-34b"],
+        "distribution_channel": "HuggingFaceSnapshot",
+        "distribution_path": "meta-llama/CodeLlama-34b-Python-hf"
+    },
+    "mistralai/Mistral-7B-v0.1": {
+        "aliases": ["mistral-7b"],
+        "distribution_channel": "HuggingFaceSnapshot",
+        "distribution_path": "mistralai/Mistral-7B-v0.1",
+        "transformer_params_key": "Mistral-7B"
+    },
+    "mistralai/Mistral-7B-Instruct-v0.1": {
+        "aliases": ["mistral-7b-instruct-v1"],
+        "distribution_channel": "HuggingFaceSnapshot",
+        "distribution_path": "mistralai/Mistral-7B-Instruct-v0.1",
+        "transformer_params_key": "Mistral-7B"
+    },
     "mistralai/Mistral-7B-Instruct-v0.2": {
-        "aliases": ["mistral", "mistral-7b", "mistral-7b-instruct"],
+        "aliases": ["mistral-7b-instruct-v2"],
         "distribution_channel": "HuggingFaceSnapshot",
         "distribution_path": "mistralai/Mistral-7B-Instruct-v0.2",
         "transformer_params_key": "Mistral-7B"
@@ -51,7 +68,8 @@
         "distribution_path": "openlm-research/open_llama_7b",
         "transformer_params_key": "7B"
     },
-    "stories15M": {
+    "tinyllamas/stories15M": {
+        "aliases": ["stories15M"],
         "distribution_channel": "DirectDownload",
         "distribution_path": [
             "https://huggingface.co/karpathy/tinyllamas/resolve/main/stories15M.pt",
@@ -59,7 +77,8 @@
         ],
         "checkpoint_file": "stories15M.pt"
     },
-    "stories42M": {
+    "tinyllamas/stories42M": {
+        "aliases": ["stories42M"],
         "distribution_channel": "DirectDownload",
         "distribution_path": [
             "https://huggingface.co/karpathy/tinyllamas/resolve/main/stories42M.pt",
@@ -67,7 +86,8 @@
         ],
         "checkpoint_file": "stories42M.pt"
     },
-    "stories110M": {
+    "tinyllamas/stories110M": {
+        "aliases": ["stories110M"],
         "distribution_channel": "DirectDownload",
         "distribution_path": [
             "https://huggingface.co/karpathy/tinyllamas/resolve/main/stories110M.pt",


### PR DESCRIPTION
Add download support for the remaining supported models. Update README to list model aliases/short-names. Add a sentence on CLI usage of model names.

Note that there is some inconsistency in model aliases for chat / non-chat variants (see llama-chat-13b, for example). We should fix this as a follow-up.

Test Plan:
Note that I only started the download process for each, I did not fully download all models as part of this change. We do need to validate all models prior to release.
```
python torchchat.py download codellama-7b
python torchchat.py download codellama-34b
python torchchat.py download mistral-7b
python torchchat.py download mistral-7b-instruct-v1
python torchchat.py download mistral-7b-instruct-v2
python torchchat.py download open-llama
```