### PR TITLE
Use _weight_int8pack_mm for CPU + eager

### DIFF
--- a/quantize.py
+++ b/quantize.py
@@ -359,7 +359,11 @@ def linear_forward_int8(x, weight, scales):
 
     # for now, we special-case channel-wise, because we know how to make that fast (but does not work for groupwise)
     if n_groups == 1:
-        if torch.compiler.is_compiling() or x.device.type != "cpu":
+        if (
+            torch.compiler.is_compiling()
+            or x.device.type != "cpu"
+            or torch.__version__ < "2.4"
+        ):
             return F.linear(x, weight.to(dtype=x.dtype)) * scales
         # Use int8pack_mm for CPU eager
         return torch.ops.aten._weight_int8pack_mm(


### PR DESCRIPTION
Restrict use of the op to eager + torch > 2.3 (i.e. only nightlies) and cpu

This improves the perf for
```
% python3 torchchat.py generate --dtype float16 --device cpu --quant '{"linear:int8" : {}}' --checkpoint-path checkpoints/stories110M/model.pth
```
from 21 to 54 tokens/sec on M1 Max