### PR TITLE
fix fp16/bf16 issue on runner-aoti

### DIFF
--- a/runner/run.cpp
+++ b/runner/run.cpp
@@ -157,7 +157,7 @@ float* forward(Transformer* transformer, int token, int pos) {
   torch::Tensor pos_tensor = torch::from_blob(pos_buffer, {1}, torch::kLong);
   std::vector<torch::Tensor> inputs{token_tensor, pos_tensor};
 
-  torch::Tensor result = transformer->runner->run(inputs)[0];
+  torch::Tensor result = transformer->runner->run(inputs)[0].to(torch::dtype(torch::kFloat32));
   auto logits = result[0].data_ptr();
 
 #else // __ET_MODEL__


### PR DESCRIPTION
Fixes FP16 + BF16 issue in aoti runner.

```
torchchat % ./cmake-out/aoti_run ./model_bf16.so -z ./.model-artifacts/meta-llama/Llama-2-7b-chat-hf/tokenizer.bin -t 0 -i "Once upon a time"
Failed to load ./.model-artifacts/meta-llama/Llama-2-7b-chat-hf/tokenizer.bin into a Tiktoken tokenizer. Trying sentencepiece tokenizer..
Once upon a time, there was a little girl named Lily. She loved to play outside in the sunshine. One day, she saw a big, red ball in the sky. It was the sun! She thought it was so pretty.
Lily wanted to play with the ball, but it was too high up in the sky. She tried to jump and reach it, but she couldn't. Then, she had an idea. She would use a stick to get the ball down.
Lily found a long stick and tried to reach the ball. She poked and poked, but the ball didn't come down. She was sad. But then, she saw a bird flying by. The bird had a big, red ball in its beak! Lily was so happy! She thanked the bird and played with her new ball all day long.
achieved tok/s: 65.842124
```
