### PR TITLE
Install devtoolset-10 on  `pytorch/conda-builder:cuda121`

### DIFF
--- a/.github/workflows/hqq-dtype.yml
+++ b/.github/workflows/hqq-dtype.yml
@@ -17,11 +17,13 @@ jobs:
       script: |
         echo "::group::Print machine info"
         uname -a
-        if [ $(uname -s) == Darwin ]; then
-          sysctl machdep.cpu.brand_string
-          sysctl machdep.cpu.core_count
-        fi
         echo "::endgroup::"
+
+        echo "::group::Install newer objcopy that supports --set-section-alignment"
+        yum install -y  devtoolset-10-binutils
+        export PATH=/opt/rh/devtoolset-10/root/usr/bin/:$PATH
+        echo "::endgroup::"
+
 
         echo "::group::Download checkpoints"
         # Install requirements

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -235,6 +235,11 @@ jobs:
         nvidia-smi
         echo "::endgroup::"
 
+        echo "::group::Install newer objcopy that supports --set-section-alignment"
+        yum install -y  devtoolset-10-binutils
+        export PATH=/opt/rh/devtoolset-10/root/usr/bin/:$PATH
+        echo "::endgroup::"
+
         echo "::group::Install required packages"
         pip install --pre torch  --index-url https://download.pytorch.org/whl/nightly/cu121
         pip install -r ./requirements.txt


### PR DESCRIPTION
That updates objcopy from 2.32 to 2.35

To workaround `objcopy: unrecognized option '--set-section-alignment'` introduced by  https://github.com/pytorch/pytorch/pull/124272