### PR TITLE
Port number of threads selection logic from executorch

### DIFF
--- a/runner/build_android.sh
+++ b/runner/build_android.sh
@@ -30,7 +30,7 @@ export CMAKE_OUT_DIR="cmake-out-android"
 build_runner_et() {
   rm -rf cmake-out-android
   echo "ET BUILD DIR IS ${ET_BUILD_DIR}"
-  cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=android-23 -S . -B cmake-out-android -G Ninja
+  cmake -DET_USE_ADPATIVE_THREADS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=android-23 -S . -B cmake-out-android -G Ninja
   cmake --build cmake-out-android/ -j16 --config Release --target et_run
 }
 


### PR DESCRIPTION
Summary:
Without this optimization llama3 on s22 is around 4 tok/sec. With the fix it is > 7 tok/sec

Test Plan:
./runner/build_android.sh
python3 torchchat.py download llama3
python3 torchchat.py export llama3 --output-pte-pat llama3.pte --quantize config/data/mobile.json
adb push llama3.pte /data/local/tmp/
adb push tokenizer.model /data/local/tmp/
adb shell "cd /data/local/tmp/ && ./et_run llama3.pte -z tokenizer.model -t 0 -i "Once upon" -n 124"

Reviewers:

Subscribers:

Tasks:

Tags: