### PR TITLE
do weight transform on cpu

### DIFF
--- a/build/utils.py
+++ b/build/utils.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import List
+from typing import List, Dict
 
 import torch
 
@@ -133,10 +133,20 @@ def device_sync(device="cpu"):
 
 
 #########################################################################
-###                   general utilkity functions                      ###
+###                    general utility functions                      ###
 
 
 # in fbcode, we can intercept certain local paths that
 # should be interpreted as part of an XAR package
 def canonical_path(path):
     return path
+
+
+#########################################################################
+###                    general utility functions                      ###
+
+def state_dict_device(d, device = "cpu") -> Dict:
+    for key, weight in d.items():
+        d[key] = weight.to(device=device)
+
+    return d


### PR DESCRIPTION
to avoid OOM situations, do weight transform on cpu 

load_state_dict does not have a map_location argument lich torch.load().

However, a quick check for mps suggested that when the state dict is loaded back into a model, it's placed on the device of the pre-existing device.  If this does not work as expected in scenarios, it should be quick to write a new version of load_state_dict that takes a map_location or amend the APUI for the exixsting function....

We might also avoid instantiating the state dict altogether - this is inherited from gpt fast, to enable sharing of quantization algos between torchchat and gpt-fast.