### PR TITLE
Add dtype runner aoti

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -858,12 +858,8 @@ jobs:
 
           python torchchat.py generate stories15M --temperature 0 --prompt "${PRMT}"
 
-
-          for dtype in fp32 fp16 bf16; do
-            echo "Testing export + runner with dtype=$dtype"
-            python torchchat.py export stories15M --dtype $dtype --output-pte-path ./model.pte
-            ./cmake-out/et_run ./model.pte -z ./tokenizer.bin -t 0 -i "${PRMT}"
-          done
+          python torchchat.py export stories15M --output-pte-path ./model.pte
+          ./cmake-out/et_run ./model.pte -z ./tokenizer.bin -t 0 -i "${PRMT}"
 
           echo "Tests complete."
   runner-aoti:
@@ -912,7 +908,6 @@ jobs:
           export PROMPT="Once upon a time in a land far away"
 
           python torchchat.py generate --checkpoint-path ${MODEL_DIR}/stories15M.pt --temperature 0 --prompt "${PROMPT}"
-
 
           for dtype in fp32 fp16 bf16; do
             echo "Running export + runner with dtype=$dtype"


### PR DESCRIPTION
Adds dtype tests for runner-aoti.

Runner-et does not work on fp16, see https://github.com/pytorch/torchchat/actions/runs/8872459136/job/24356835073.  I will file an issue for this.