### PR TITLE
Add cuda option in install_requirements.sh.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,25 @@ cd torchchat
 # set up a virtual environment
 python3 -m venv .venv
 source .venv/bin/activate
+```
 
+After the virtual environment is activated, dependencies can be installed. torchchat depends on pytorch. By default, torch nightly with cpu will be installed.
+
+```bash
 # install dependencies
 ./install_requirements.sh
+```
 
+If CUDA GPUs are available, the argument of "cuda" can be added to accelerate the execution.
+
+```bash
+# install dependencies
+./install_requirements.sh cuda
+```
+
+Installations can be tested by
+
+```bash
 # ensure everything installed correctly
 python3 torchchat.py --help
 ```

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -41,8 +41,16 @@ $PIP_EXECUTABLE install -r requirements.txt
 # package versions.
 NIGHTLY_VERSION=dev20240422
 
-# The pip repository that hosts nightly torch packages.
+# The pip repository that hosts nightly torch packages. cpu by default.
 TORCH_NIGHTLY_URL="https://download.pytorch.org/whl/nightly/cpu"
+
+# If cuda is available, use "cuda" argument to install the pytorch nightly
+# with cuda for faster execution on cuda GPUs.
+if [ "$1" == "cuda" ]
+then
+TORCH_NIGHTLY_URL="https://download.pytorch.org/whl/nightly/cu121"
+fi
+
 
 # pip packages needed by exir.
 REQUIREMENTS_TO_INSTALL=(


### PR DESCRIPTION
Originally install_requirements.sh would just install the cpu nightly of pytorch. torchchat would run much faster if there are compatible GPUs. Add the "cuda" option to install pytorch nightly with cuda. 