### PR TITLE
Fix build_native.sh aoti

### DIFF
--- a/scripts/build_native.sh
+++ b/scripts/build_native.sh
@@ -62,17 +62,16 @@ fi
 
 source "$TORCHCHAT_ROOT/scripts/install_utils.sh"
 
+pushd ${TORCHCHAT_ROOT}
 git submodule update --init
 git submodule sync
-
 if [[ "$TARGET" == "et" ]]; then
-    pushd ${TORCHCHAT_ROOT}
     find_cmake_prefix_path
     install_pip_dependencies
     clone_executorch
     install_executorch_libs false
-    popd
 fi
+popd
 
 # CMake commands
 cmake -S . -B ./cmake-out -DCMAKE_PREFIX_PATH=`python -c 'import torch;print(torch.utils.cmake_prefix_path)'` -G Ninja


### PR DESCRIPTION
Summary: Fix the following error:

```
“CMake Error at tokenizer/CMakeLists.txt:23 (add_subdirectory):
  The source directory
    /<omitted>/torchchat/torchchat/tokenizer/third-party/abseil-cpp   does not contain a CMakeLists.txt file.

CMake Error at tokenizer/CMakeLists.txt:24 (add_subdirectory):
  The source directory

    /<omitted>/torchchat/torchchat/tokenizer/third-party/re2  does not contain a CMakeLists.txt file.”
```

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: