### PR TITLE
Automatically detect the cuda availability and install corresponding …

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,18 +56,11 @@ python3 -m venv .venv
 source .venv/bin/activate
 ```
 
-After the virtual environment is activated, dependencies can be installed. torchchat depends on pytorch. By default, torch nightly with cpu will be installed.
+After the virtual environment is activated, dependencies can be installed.
 
 ```bash
 # install dependencies
 ./install_requirements.sh
-```
-
-If CUDA GPUs are available, the argument of "cuda" can be added to accelerate the execution.
-
-```bash
-# install dependencies
-./install_requirements.sh cuda
 ```
 
 Installations can be tested by

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -44,13 +44,8 @@ NIGHTLY_VERSION=dev20240422
 # The pip repository that hosts nightly torch packages. cpu by default.
 TORCH_NIGHTLY_URL="https://download.pytorch.org/whl/nightly/cpu"
 
-# If cuda is available, use "cuda" argument to install the pytorch nightly
-# with cuda for faster execution on cuda GPUs.
-if [ "$1" == "cuda" ]
-then
-TORCH_NIGHTLY_URL="https://download.pytorch.org/whl/nightly/cu121"
-fi
-
+# If cuda is available, use the pytorch nightly with cuda for faster execution on cuda GPUs.
+test -f /usr/bin/nvidia-smi && TORCH_NIGHTLY_URL="https://download.pytorch.org/whl/nightly/cu121"
 
 # pip packages needed by exir.
 REQUIREMENTS_TO_INSTALL=(


### PR DESCRIPTION
…torch nightly

Use `test -f /usr/bin/nvidia-smi` to automatically detect the cuda availability instead of manually set by argument.

Thanks @malfet and @mikekgfb for the suggestion!