### PR TITLE
Mitigate ET linker crashes by pining to a specific commit

### DIFF
--- a/scripts/install_utils.sh
+++ b/scripts/install_utils.sh
@@ -27,7 +27,7 @@ clone_executorch() {
   pushd ${TORCHCHAT_ROOT}/${ET_BUILD_DIR}/src
   git clone https://github.com/pytorch/executorch.git
   cd executorch
-  git checkout main
+  git checkout f0f4db877dd649c4e8ce951a4ccc3827841e9ad3
   echo "Install executorch: submodule update"
   git submodule sync
   git submodule update --init


### PR DESCRIPTION
Picked https://github.com/pytorch/executorch/commit/f0f4db877dd649c4e8ce951a4ccc3827841e9ad3 and it seems to mitigate the crashes that manifested as follows:
```
   0  0x104ac3648  __assert_rtn + 72
   1  0x1049ebc5c  ld::Fixup::applyFixup(ld::Atom const*, ld::LayoutLinkedImage const&, unsigned char*) const + 8268
   2  0x104a7e7d8  ___ZN2ld16LayoutExecutable27writeContentWithoutLinkEditENSt3__14spanIhLm18446744073709551615EEEy_block_invoke + 332
   3  0x19af0a428  _dispatch_client_callout2 + 20
   4  0x19af1e850  _dispatch_apply_invoke3 + 336
   5  0x19af0a3e8  _dispatch_client_callout + 20
   6  0x19af0bc68  _dispatch_once_callout + 32
   7  0x19af1eeec  _dispatch_apply_invoke_and_wait + 372
   8  0x19af1de9c  _dispatch_apply_with_attr_f + 1212
   9  0x19af1e08c  dispatch_apply + 96
   10  0x104a7e9e4  void mapReduce<ld::Atom const*, mach_o::Error>(std::__1::span<ld::Atom const*, 18446744073709551615ul>, unsigned long, void (unsigned long, mach_o::Error&, std::__1::span<ld::Atom const*, 18446744073709551615ul>) block_pointer, void (std::__1::span<mach_o::Error, 18446744073709551615ul>) block_pointer) + 336
   11  0x104a7e594  ld::LayoutExecutable::writeContentWithoutLinkEdit(std::__1::span<unsigned char, 18446744073709551615ul>, unsigned long long) + 1180
   12  0x104a84020  ld::LayoutExecutable::writeToFile(char const*) + 15248
   13  0x104a362e8  main + 9424
   ld: Assertion failed: (extras.otherInstrOffset != 0 && "Kind::arm64_adrp_ldr missing extra info"), function applyFixup, file Fixup.cpp, line 793.
   clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

TODOS:
 - [ ] Bisect this to a specific change
 - [ ] Check if moving to newer Xcode will work
 - [ ] Write a workflow that auto-updates PT + ET pins