### PR TITLE
Update install_utils.sh to use python3 instead of python

### DIFF
--- a/scripts/install_utils.sh
+++ b/scripts/install_utils.sh
@@ -16,7 +16,7 @@ install_pip_dependencies() {
 }
 
 function find_cmake_prefix_path() {
-  path=`python -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())"`
+  path=`python3 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())"`
   MY_CMAKE_PREFIX_PATH=$path
 }
 


### PR DESCRIPTION
As titled. On some devices `python` and `python3` are pointing to different environments so good to unify them.