### PR TITLE
Fix typo

### DIFF
--- a/build/utils.py
+++ b/build/utils.py
@@ -228,7 +228,7 @@ def is_mps_available() -> bool:
     # so let's set up some memry, and see if that work:
     try:
         mps_tensor = torch.zeros(1024, dtype=torch.float16, device="mps")
-    except:
+    except RuntimeError:
         return False
 
     # MPS, is that you?


### PR DESCRIPTION
`torch.zero`->`torch.zeros`, as former does not exist.

Also, capture only `RuntimeErrors` to avoid making such typos in the future