### PR TITLE
Update aoti.cmake to enforce torch version

### DIFF
--- a/runner/aoti.cmake
+++ b/runner/aoti.cmake
@@ -8,7 +8,7 @@ ENDIF()
 
 find_package(CUDA)
 
-find_package(Torch)
+find_package(Torch 2.4.0)
 if(Torch_FOUND)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g ${TORCH_CXX_FLAGS} -fpermissive")
 


### PR DESCRIPTION
As titled. This is to make sure we are locating the libtorch.so/dylib with the correct version number.