### PR TITLE
Fix LinearInt8 recursive quantization

### DIFF
--- a/quantize.py
+++ b/quantize.py
@@ -410,8 +410,8 @@ class WeightOnlyInt8QuantHandler(QuantHandler):
                             groupsize=self.groupsize,
                         ),
                     )
-                else:
-                    self.quantize(child)
+            else:
+                self.quantize(child)
 
         return module
 


### PR DESCRIPTION
By balancing `else:` to the right `if isinstance(child, nn.Linear):`
Test plan:
```
% python3 torchchat.py generate llama2 --dtype float16 --quantize '{"linear:int8": {"groupsize": 0}}' --prompt "Once upon a time," --device mps
Using device=mps 
Loading model...
Time to load model: 29.03 seconds
Quantizing the model with: {'linear:int8': {'groupsize': 0}}
Time to quantize model: 14.37 seconds
```

Fixes https://github.com/pytorch/torchchat/issues/788