### PR TITLE
Swap out deprecated runner

### DIFF
--- a/.ci/scripts/gather_test_models.py
+++ b/.ci/scripts/gather_test_models.py
@@ -26,7 +26,7 @@ MODEL_REPOS = {
 
 JOB_RUNNERS = {
     "cpu": {
-        "8-core-ubuntu": "x86_64",
+        "8-core": "x86_64",
         # "macos-12": "x86_64", # not working for complie and ExecuTorch yet
         "macos-14": "aarch64",
     },


### PR DESCRIPTION
Github is deprecating the `N-core-ubuntu` runner label, replacing it with `N-core`. 

This only affects how github queues jobs, not where those jobs actually run

More details in https://github.com/pytorch/pytorch/issues/125721