### PR TITLE
Swap out deprecated runner

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -426,7 +426,7 @@ jobs:
   test-tinystories-executorch:
     strategy:
       matrix:
-        runner: [16-core-ubuntu, macos-14-xlarge]
+        runner: [16-core, macos-14-xlarge]
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout repo
@@ -868,7 +868,7 @@ jobs:
   runner-et:
     strategy:
       matrix:
-        runner: [16-core-ubuntu, macos-14-xlarge]
+        runner: [16-core, macos-14-xlarge]
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout repo
@@ -963,7 +963,7 @@ jobs:
   runner-aoti:
     strategy:
       matrix:
-        runner: [16-core-ubuntu, macos-14-xlarge]
+        runner: [16-core, macos-14-xlarge]
     runs-on: ${{matrix.runner}}
     env:
       TORCHCHAT_ROOT: ${{ github.workspace }}


### PR DESCRIPTION
Github is deprecating the `N-core-ubuntu` runner label, replacing it with `N-core`.  We need to migrate PyTorch runners accordingly

This only affects how github queues jobs, not where those jobs actually run

More details in https://github.com/pytorch/pytorch/issues/125721