### PR TITLE
[NOT FOR LAND][POC] Export friendly XNNPACK prepack

### DIFF
--- a/custom_op/CMakeLists.txt
+++ b/custom_op/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+project(custom_linear_op)
+
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(Torch REQUIRED)
+message("${TORCH_LIBRARIES}")
+
+add_library(custom_linear_op SHARED cache.cpp op.cpp)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+target_include_directories(custom_linear_op PRIVATE "${TORCH_INCLUDE_DIRS}")
+target_link_libraries(custom_linear_op PRIVATE "${TORCH_LIBRARIES}")
+target_compile_features(custom_linear_op PRIVATE cxx_range_for)

--- a/custom_op/cache.cpp
+++ b/custom_op/cache.cpp
@@ -1,0 +1,123 @@
+#include <op.h>
+
+XNNWeightsCache::XNNWeightsCache() {
+    weights_cache_.context = this;
+    weights_cache_.look_up = (size_t(*)(
+        void*, const xnn_weights_cache_look_up_key*))XNNWeightsCache::look_up;
+    weights_cache_.reserve_space =
+        (void* (*)(void*, size_t))XNNWeightsCache::reserve_space;
+    weights_cache_.look_up_or_insert =
+        (size_t(*)(void*, const xnn_weights_cache_look_up_key*, void*, size_t))
+            XNNWeightsCache::look_up_or_insert;
+    weights_cache_.is_finalized = (bool (*)(void*))XNNWeightsCache::is_finalized;
+    weights_cache_.offset_to_addr =
+        (void* (*)(void*, size_t))XNNWeightsCache::offset_to_addr;
+    weights_cache_.delete_cache =
+        (enum xnn_status(*)(void*))XNNWeightsCache::delete_cache;
+}
+
+XNNWeightsCache::XNNWeightsCache(const at::Tensor& weight) : XNNWeightsCache() {
+    from_tensor_ = true;
+    buffer_for_packed_weights_.resize(weight.numel() + alignment_, 5);
+    void* start = get_aligned(buffer_for_packed_weights_.data());
+    memcpy(start, weight.data_ptr(), weight.numel());
+}
+
+at::Tensor XNNWeightsCache::to_tensor() {
+    auto options = torch::TensorOptions().dtype(torch::kUInt8).device(torch::kCPU);
+    void* start = get_aligned(buffer_for_packed_weights_.data());
+    size_t packed_weight_size = buffer_for_packed_weights_.size() - alignment_;
+    auto t =  at::from_blob(
+            start,
+            {(int64_t)(packed_weight_size)},
+            options);
+    return t.clone();
+}
+
+bool XNNWeightsCache::registerWeight(std::string name, const void* data) {
+    weights_to_name_[data] = name;
+    return true;
+}
+
+bool XNNWeightsCache::Finalize() {
+    is_finalized_ = true;
+    return true;
+}
+
+xnn_weights_cache_t XNNWeightsCache::Get() {
+    return (xnn_weights_cache_t)&weights_cache_;
+}
+
+size_t XNNWeightsCache::look_up(
+    XNNWeightsCache* context,
+    const xnn_weights_cache_look_up_key* cache_key) {
+    const void* unpacked_weights_ptr = cache_key->kernel;
+    if (context->from_tensor_) {
+        return 0;
+    }
+    if (auto entry = context->weights_to_name_.find(unpacked_weights_ptr);
+        entry != context->weights_to_name_.end()) {
+        std::string weight_name = entry->second;
+        if (auto entry = context->name_to_offset_size_.find(weight_name);
+            entry != context->name_to_offset_size_.end()) {
+        return (size_t)(entry->second.first);
+        }
+    }
+    return SIZE_MAX;
+}
+
+void* XNNWeightsCache::reserve_space(XNNWeightsCache* context, size_t n) {
+    context->buffer_for_packed_weights_.resize(n + context->alignment_);
+    void* maybe_aligned_space = context->buffer_for_packed_weights_.data();
+    void* aligned_ptr = context->get_aligned(maybe_aligned_space);
+    return aligned_ptr;
+}
+
+size_t XNNWeightsCache::look_up_or_insert(
+    XNNWeightsCache* context,
+    const xnn_weights_cache_look_up_key* cache_key,
+    void* ptr,
+    size_t size) {
+    size_t offset = context->look_up(context, cache_key);
+
+    if (offset != SIZE_MAX) {
+        void* saved_ptr = offset_to_addr(context, offset);
+        if (0 == memcmp(ptr, saved_ptr, size)) {
+            return offset;
+        }
+        // Failure, cache is out of date
+        return SIZE_MAX;
+    }
+
+    const void* unpacked_weights_ptr = cache_key->kernel;
+    if (auto entry = context->weights_to_name_.find(unpacked_weights_ptr);
+        entry != context->weights_to_name_.end()) {
+        std::string weight_name = entry->second;
+        size_t offset = context->offset_tracking_++;
+        context->name_to_offset_size_[weight_name] = std::make_pair(offset, size);
+        context->offset_to_addr_[offset] = ptr;
+        return offset;
+    }
+    return SIZE_MAX;
+}
+
+bool XNNWeightsCache::is_finalized(XNNWeightsCache* context) {
+    return context->is_finalized_;
+}
+
+void* XNNWeightsCache::offset_to_addr(XNNWeightsCache* context, size_t offset) {
+    if (context->from_tensor_ and !offset) {
+        void* ptr = context->buffer_for_packed_weights_.data();
+        void* aligned_ptr = context->get_aligned(ptr);
+        return aligned_ptr;
+    }
+    if (auto entry = context->offset_to_addr_.find(offset);
+        entry != context->offset_to_addr_.end()) {
+        return entry->second;
+    }
+    return nullptr;
+}
+
+enum xnn_status XNNWeightsCache::delete_cache(XNNWeightsCache* context) {
+    return xnn_status_success;
+}

--- a/custom_op/linear.py
+++ b/custom_op/linear.py
@@ -1,0 +1,58 @@
+from typing import Optional
+
+import torch
+import torch.nn as nn
+from random import randrange
+
+torch.ops.load_library(
+    "/Users/digantdesai/local/custom_op/build/libcustom_linear_op.dylib"
+)
+
+class CustomLinear(nn.Module):
+    def __init__(
+        self, weight: torch.Tensor, bias: Optional[torch.Tensor] = None
+    ) -> None:
+        super().__init__()
+        self.weight = weight
+        self.bias = bias
+        assert self.bias is None # TODO
+        self.input_channels = self.weight.shape[1]
+        self.output_channels = self.weight.shape[0]
+        self.weight_key = torch.ops.customlinear.get_weights_key(self.weight)
+        self.packed_weights = torch.ops.customlinear.prepack_weights(self.weight)
+
+    def forward(self, x):
+        print("Running custom linear")
+        return torch.ops.customlinear.run(x, self.packed_weights, self.input_channels, self.output_channels, self.weight_key)
+
+        # # Run the custom op without packed weights
+        # return torch.ops.customlinear.prepack_and_run(x, self.weight)
+
+        # # Run without the custom op
+        # return torch.nn.functional.linear(x, self.weight, self.bias)
+
+
+def replace_linear_with_custom_linear(module: nn.Module):
+    for name, child in module.named_children():
+        if isinstance(child, nn.Linear):
+            setattr(module, name, CustomLinear(child.weight, child.bias))
+        else:
+            replace_linear_with_custom_linear(child)
+
+if __name__ == "__main__":
+    ic = randrange(2, 6);
+    oc = randrange(2, 6);
+    bs = randrange(2, 6);
+    input = torch.rand((bs, ic))
+    with torch.no_grad():
+        model = nn.Sequential(nn.Linear(ic, oc, bias=False)).eval()
+        ref = model(input)
+
+        replace_linear_with_custom_linear(model)
+        xnn = model(input)
+
+        print(f"shapes: bs: {bs}, oc: {oc}, ic: {oc}")
+        print(f"Functional: {ref}")
+        print(f"Custom XNN: {xnn}")
+        print(f"Success? {torch.allclose(ref, xnn)}")
+        print("---")

--- a/custom_op/op.cpp
+++ b/custom_op/op.cpp
@@ -1,0 +1,125 @@
+#include <op.h>
+
+int64_t get_key(
+    at::Tensor weight) {
+    uintptr_t weight_ptr = (uintptr_t)weight.data_ptr<float>();
+    assert (weight_ptr < std::numeric_limits<int64_t>::max());
+    return (int64_t)weight_ptr;
+}
+
+at::Tensor prepack(
+    at::Tensor weight) {
+    xnn_status status = xnn_initialize(/*allocator=*/nullptr);
+    TORCH_CHECK(status == xnn_status_success, "failed to initialize XNNPACK");
+
+    const float output_min = -std::numeric_limits<float>::infinity();
+    const float output_max = std::numeric_limits<float>::infinity();
+
+    auto output_channels = weight.size(0);
+    auto input_channels = weight.size(1);
+    auto xnn_weights_cache = std::make_unique<XNNWeightsCache>();
+
+    xnn_weights_cache->registerWeight("weight_1", weight.data_ptr<float>());
+
+    xnn_operator_t linear_op = nullptr;
+
+    xnn_status create_status = xnn_create_fully_connected_nc_f32(
+        input_channels,                        // input_channels
+        output_channels,                       // output_channels
+        input_channels,                        // input_pixel_stride
+        output_channels,                       // output_pixel_stride
+        weight.contiguous().data_ptr<float>(), // kernel
+        nullptr,                               // bias
+        output_min,                            // output_min
+        output_max,                            // output_max
+        0u,                                    // flags
+        nullptr,                               // xnn_caches_t
+        xnn_weights_cache->Get(),               // xnn_weights_cache_t
+        &linear_op);                           // operator
+
+    TORCH_CHECK(
+        xnn_status_success == create_status,
+        "xnn_create_fully_connected_nc_f32 failed!", create_status);
+
+    xnn_weights_cache->Finalize();
+
+    const auto cache_tensor = xnn_weights_cache->to_tensor();
+    return cache_tensor;
+}
+
+at::Tensor run(
+    at::Tensor input,
+    const at::Tensor& packed_weights,
+    const int64_t input_channels,
+    const int64_t output_channels,
+    const int64_t weight_ptr) {
+
+    auto batch_size = input.size(0);
+    auto options = torch::TensorOptions().dtype(torch::kFloat32);
+    auto output = torch::empty({batch_size, (int64_t) output_channels}, options);
+
+    const float output_min = -std::numeric_limits<float>::infinity();
+    const float output_max = std::numeric_limits<float>::infinity();
+
+    auto xnn_weights_cache = std::make_unique<XNNWeightsCache>(packed_weights);
+
+    xnn_operator_t linear_op = nullptr;
+    const xnn_status create_status = xnn_create_fully_connected_nc_f32(
+        (size_t) input_channels,               // input_channels
+        (size_t) output_channels,              // output_channels
+        input_channels,                        // input_pixel_stride
+        output_channels,                       // output_pixel_stride
+        (const float*) weight_ptr,             // kernel - should be only used as a key to the weight cache, else we will go belly up!
+        nullptr,                               // bias
+        output_min,                            // output_min
+        output_max,                            // output_max
+        0u,                                    // flags
+        nullptr,                               // xnn_caches_t
+        xnn_weights_cache->Get(),              // xnn_weights_cache_t
+        &linear_op);                           // operator
+
+    xnn_weights_cache->Finalize();
+
+    const xnn_status reshape_status = xnn_reshape_fully_connected_nc_f32(
+      linear_op,                              // operator
+      batch_size,                             // batch_size
+      nullptr);                               // threadpool
+
+    TORCH_CHECK(
+        xnn_status_success == reshape_status,
+        "xnn_reshape_fully_connected_nc_f32 failed!", reshape_status);
+
+    const xnn_status setup_status = xnn_setup_fully_connected_nc_f32(
+      linear_op,                              // operator
+      input.data_ptr<float>(),                // input
+      output.data_ptr<float>());              // output
+
+    TORCH_CHECK(
+        xnn_status_success == setup_status,
+        "xnn_setup_fully_connected_nc_f32 failed!", setup_status);
+
+    const xnn_status run_status = xnn_run_operator(
+      linear_op,                              // operator
+      nullptr);                               // threadpool
+
+    TORCH_INTERNAL_ASSERT(
+        xnn_status_success == run_status,
+        "xnn_run_operator failed!", run_status);
+
+    return output;
+}
+
+at::Tensor prepack_and_run(
+    at::Tensor input,
+    at::Tensor weights) {
+    int64_t weight_key = get_key(weights);
+    auto packed_weights = prepack(weights);
+    return run(input, packed_weights, weights.size(1), weights.size(0), weight_key);
+}
+
+TORCH_LIBRARY(customlinear, m) {
+  m.def("get_weights_key", get_key);
+  m.def("prepack_weights", prepack);
+  m.def("run", run);
+  m.def("prepack_and_run", prepack_and_run);
+}

--- a/custom_op/op.h
+++ b/custom_op/op.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <torch/library.h>
+#include <torch/script.h>
+#include <xnnpack.h>
+
+class XNNWeightsCache {
+   public:
+    XNNWeightsCache();
+    bool registerWeight(std::string name, const void* data);
+    bool Finalize();
+    xnn_weights_cache_t Get();
+    XNNWeightsCache(const at::Tensor& tensor);
+    at::Tensor to_tensor();
+
+   private:
+    bool is_finalized_ = false;
+    size_t offset_tracking_ = 0;
+    std::map<const void*, std::string> weights_to_name_;
+    std::map<std::string, std::pair<size_t, size_t>> name_to_offset_size_;
+    std::map<size_t, void*> offset_to_addr_;
+    bool from_tensor_ = false;
+    size_t alignment_ = 64;
+    size_t buffer_size = 0;
+    std::string buffer_for_packed_weights_;
+    xnn_weights_cache_provider weights_cache_;
+
+    void* get_aligned(void* ptr) {
+        return (void*)((intptr_t)ptr + alignment_ - (intptr_t)ptr % alignment_);
+    }
+
+    static size_t look_up(
+        XNNWeightsCache* context,
+        const xnn_weights_cache_look_up_key* cache_key);
+
+    static void* reserve_space(XNNWeightsCache* context, size_t n);
+
+    static size_t look_up_or_insert(
+        XNNWeightsCache* context,
+        const xnn_weights_cache_look_up_key* cache_key,
+        void* ptr,
+        size_t size);
+
+    static bool is_finalized(XNNWeightsCache* context);
+
+    static void* offset_to_addr(XNNWeightsCache* context, size_t offset);
+
+    static enum xnn_status delete_cache(XNNWeightsCache* context);
+};

--- a/custom_op/script.sh
+++ b/custom_op/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+function configure() {
+    cd $script_dir
+    rm -rf build
+    mkdir -p build
+    cd build
+    cmake -DCMAKE_PREFIX_PATH="$(python -c 'import torch.utils; print(torch.utils.cmake_prefix_path)')" ..
+}
+
+
+function build() {
+    cd $script_dir/build
+    make -j
+}
+
+function run() {
+    cd $script_dir
+    for i in 0 1 2 3; do
+        python ./linear.py
+    done
+}
+
+$@


### PR DESCRIPTION
Rationale: This will allow us to use xnnpack linear ops without using custom classes.

This proof of concept a linear custom op introduces xnnpack prepacking without using custom class to hold the packed weights in its instance. This is done through dumping and reconstructing xnnpack weight cache to and from a at::Tensor respectively.

There is a slight perf loss from re-creating xnnpack op again for each inference.