### PR TITLE
Using python3 in build_native.sh

### DIFF
--- a/scripts/build_native.sh
+++ b/scripts/build_native.sh
@@ -74,7 +74,7 @@ fi
 popd
 
 # CMake commands
-cmake -S . -B ./cmake-out -DCMAKE_PREFIX_PATH=`python -c 'import torch;print(torch.utils.cmake_prefix_path)'` -G Ninja
+cmake -S . -B ./cmake-out -DCMAKE_PREFIX_PATH=`python3 -c 'import torch;print(torch.utils.cmake_prefix_path)'` -G Ninja
 cmake --build ./cmake-out --target "${TARGET}"_run
 
 printf "Build finished. Please run: \n./cmake-out/${TARGET}_run model.<pte|so> -z tokenizer.model -l <llama version (2 or 3)> -i <prompt>\n"


### PR DESCRIPTION
So that users on say Ubuntu 20.04 can use the script, because to the `python` is still 2.7:
```
$ cat /etc/issue; python --version
Ubuntu 20.04.5 LTS \n \l

Python 2.7.18
```