### PR TITLE
increase timeout for quantization test on MPS

### DIFF
--- a/.github/workflows/run-readme-pr-mps.yml
+++ b/.github/workflows/run-readme-pr-mps.yml
@@ -35,7 +35,8 @@ jobs:
   test-quantization-mps-macos:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
-      runner: macos-m1-14  
+      runner: macos-m1-14
+      timeout: 60
       script: |
           set -x
           conda create -y -n test-quantization-mps-macos python=3.10.11


### PR DESCRIPTION
increase timeout for quantization test on MPS.

This is a new test and runs very slowly on MPS.  may be an indicator that quantized functions are not as fast as we'd like them to be?  That being said, it seems we pass CPU tests)