### PR TITLE
Pin ao to 0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Requires python >=3.10
 
 # PyTorch ecosystem
-torchao
+torchao==0.1
 
 # Hugging Face download
 huggingface_hub


### PR DESCRIPTION
ao just made a release today where our default binaries on pypi are cuda binaries https://github.com/pytorch/ao/releases/tag/v0.2.0 which is breaking torchat ci

So short term fix is this PR which is to downgrade the ao version to unblock https://github.com/pytorch/torchchat/issues/843 since right now torchchat is using an unpinned dependency

  Longer term fix we will upload cpu only binaries on pytorch.org - cc @huydhn 