### PR TITLE
Don't count profiling or import contextlib in tokens/sec

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -697,16 +697,16 @@ def _main(
                     is_llama3_model=is_llama3_model,
                 )
 
-        t0 = time.perf_counter()
-        import contextlib
 
         if (i != generator_args.num_samples - 1 or not profile) or (
             use_tp and rank != 0
         ):
+            import contextlib
             prof = contextlib.nullcontext()
         else:
             torch.profiler._utils._init_for_cuda_graphs()
             prof = torch.profiler.profile()
+        t0 = time.perf_counter()
         with prof:
             y, metrics = generate(
                 model,


### PR DESCRIPTION
Raises llama2 reported tokens per second on M1 Pro using latest PyTorch from 3.6 to 4.3. (`python3 torchchat.py generate  llama2 --dtype fp16  --prompt "Once upon a time," --temperature 0 --device cpu`)
