### PR TITLE
Updating lm_eval version 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ snakeviz
 sentencepiece
 numpy
 gguf
-lm-eval==0.4
+lm-eval==0.4.2
 blobfile
 
 # Build tools


### PR DESCRIPTION
lm-eval 0.4.0 no longer plays nice with the underlying datasets versions (See https://github.com/EleutherAI/lm-evaluation-harness/issues/1980) and breaks CI

This bumps the version