### PR TITLE
Pinning numpy to under 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ tiktoken
 # Miscellaneous
 snakeviz
 sentencepiece
-numpy
+numpy < 2.0
 gguf
 lm-eval==0.4.2
 blobfile


### PR DESCRIPTION
Numpy 2.0 was released on June 16th, 2024 and is BC Breaking

It is also new enough that it isn't compatible with a bunch of frameworks specifically GGUF (which breaks any CI that uses GGUF). 

This just pins numpy to before 2.0 until things are ready for it