### PR TITLE
Update install_requirements.sh

### DIFF
--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -18,7 +18,7 @@ then
 fi
 
 # Check python version. Expect 3.10.x or 3.11.x
-printf "import sys\nif sys.version_info.major != 3 or sys.version_info.minor < 10 :\n\tprint('Please use Python >=3.10');sys.exit(1)\n" | python3
+printf "import sys\nif sys.version_info.major != 3 or sys.version_info.minor < 10 :\n\tprint('Please use Python >=3.10');sys.exit(1)\n" | $PYTHON_EXECUTABLE
 if [[ $? -ne 0 ]]
 then
   exit 1


### PR DESCRIPTION
Current install_requirements.sh statically uses python3 to check python version; however, python3 may not exist in user's env and we may not use python3 during installation. Change to use $PYTHON_EXECUTABLE instead.