### PR TITLE
Cleaning up --help: Gate Evaluation Arguments

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -230,6 +230,31 @@ def add_arguments_for_verb(parser, verb: str):
         choices=["fast", "cpu", "cuda", "mps"],
         help="Hardware device to use. Options: cpu, cuda, mps",
     )
+    
+    if verb == "eval":
+        _add_evaluation_args(parser)
+    
+    parser.add_argument(
+        "--hf-token",
+        type=str,
+        default=None,
+        help="A HuggingFace API token to use when downloading model artifacts",
+    )
+    parser.add_argument(
+        "--model-directory",
+        type=Path,
+        default=default_model_dir,
+        help=f"The directory to store downloaded model artifacts. Default: {default_model_dir}",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=5000,
+        help="Port for the web server in browser mode",
+    )
+
+# Add CLI Args specific to Model Evaluation
+def _add_evaluation_args(parser) -> None:
     parser.add_argument(
         "--tasks",
         nargs="+",
@@ -248,24 +273,6 @@ def add_arguments_for_verb(parser, verb: str):
         type=int,
         default=None,
         help="Maximum length sequence to evaluate",
-    )
-    parser.add_argument(
-        "--hf-token",
-        type=str,
-        default=None,
-        help="A HuggingFace API token to use when downloading model artifacts",
-    )
-    parser.add_argument(
-        "--model-directory",
-        type=Path,
-        default=default_model_dir,
-        help=f"The directory to store downloaded model artifacts. Default: {default_model_dir}",
-    )
-    parser.add_argument(
-        "--port",
-        type=int,
-        default=5000,
-        help="Port for the web server in browser mode",
     )
 
 


### PR DESCRIPTION
The current --help is a mess; it uses a giant `add_arguments_for_verb` function that doesn't actually filter based on the provided verb subcommand.
 
This PR is part of a series to clean up this behavior. 

Specifically, this PR restricts args that are utilized solely for perplexity evaluation to just the `eval` subcommand.
* Note this does not do the inverse. `Eval` still has args that are unrelated to `eval`. This is addressed later

---

**python3 torchchat.py generate --help**
```
usage: torchchat generate [-h] [--chat] [--distributed] [--gui] [--prompt PROMPT] [--is-chat-model] [--seed SEED] [--num-samples NUM_SAMPLES] [--max-new-tokens MAX_NEW_TOKENS] [--top-k TOP_K] [--temperature TEMPERATURE] [--compile]
                          [--compile-prefill] [--sequential-prefill] [--profile PROFILE] [--speculate-k SPECULATE_K] [--draft-checkpoint-path DRAFT_CHECKPOINT_PATH] [--checkpoint-path CHECKPOINT_PATH] [--params-path PARAMS_PATH]
                          [--gguf-path GGUF_PATH] [--tokenizer-path TOKENIZER_PATH] [--output-pte-path OUTPUT_PTE_PATH] [--output-dso-path OUTPUT_DSO_PATH] [--dso-path DSO_PATH] [--pte-path PTE_PATH]
                          [--dtype {fp32,fp16,bf16,float,half,float32,float16,bfloat16,fast,fast16}] [-v] [--quantize QUANTIZE] [--draft-quantize DRAFT_QUANTIZE]
                          [--params-table {13B,70B,CodeLlama-7b-Python-hf,34B,stories42M,30B,stories110M,7B,stories15M,Mistral-7B,Meta-Llama-3-8B}] [--device {fast,cpu,cuda,mps}] [--hf-token HF_TOKEN] [--model-directory MODEL_DIRECTORY]
                          [--port PORT]
                          [model]
...
```

**python3 torchchat.py eval --help**
```
usage: torchchat eval [-h] [--chat] [--distributed] [--gui] [--prompt PROMPT] [--is-chat-model] [--seed SEED] [--num-samples NUM_SAMPLES] [--max-new-tokens MAX_NEW_TOKENS] [--top-k TOP_K] [--temperature TEMPERATURE] [--compile]
                      [--compile-prefill] [--sequential-prefill] [--profile PROFILE] [--speculate-k SPECULATE_K] [--draft-checkpoint-path DRAFT_CHECKPOINT_PATH] [--checkpoint-path CHECKPOINT_PATH] [--params-path PARAMS_PATH]
                      [--gguf-path GGUF_PATH] [--tokenizer-path TOKENIZER_PATH] [--output-pte-path OUTPUT_PTE_PATH] [--output-dso-path OUTPUT_DSO_PATH] [--dso-path DSO_PATH] [--pte-path PTE_PATH]
                      [--dtype {fp32,fp16,bf16,float,half,float32,float16,bfloat16,fast,fast16}] [-v] [--quantize QUANTIZE] [--draft-quantize DRAFT_QUANTIZE]
                      [--params-table {13B,70B,CodeLlama-7b-Python-hf,34B,stories42M,30B,stories110M,7B,stories15M,Mistral-7B,Meta-Llama-3-8B}] [--device {fast,cpu,cuda,mps}] [--tasks TASKS [TASKS ...]] [--limit LIMIT]
                      [--max-seq-length MAX_SEQ_LENGTH] [--hf-token HF_TOKEN] [--model-directory MODEL_DIRECTORY] [--port PORT]
                      [model]

...
```
---
Notice how **_tasks_**, **_max-seq-length_**, and **_limit_** only show up as args for eval