### PR TITLE
Move compile prefill out of generator parser to generic arg

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -85,7 +85,7 @@ def add_arguments_for_verb(parser, verb: str) -> None:
         action="store_true",
         help="Whether to compile the model with torch.compile",
     )
-    generator_parser.add_argument(
+    parser.add_argument(
         "--compile-prefill",
         action="store_true",
         help="Whether to compile the prefill. Improves prefill perf, but has higher compile times.",


### PR DESCRIPTION
Compile Prefill is only used for generation, but there is currently legacy logic that checks for this field outside of a generation context. Moved back to a generic parser arg to unblock for testing until arg_init is cleaned up