### PR TITLE
Refactor generate.py for modularity (#906)

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -4,8 +4,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 import argparse
-import time
-from typing import Optional
+from typing import Callable, Optional
 
 import torch
 import torch._dynamo.config
@@ -20,7 +19,6 @@ from build.builder import (
 from build.model import Transformer
 from build.utils import set_precision
 from cli import add_arguments_for_verb, arg_init
-from generate import encode_tokens, model_forward
 from utils.measure_time import measure_time
 
 torch._dynamo.config.automatic_dynamic_shapes = True
@@ -85,11 +83,17 @@ class GPTFastEvalWrapper(eval_wrapper):
         self,
         model: Transformer,
         tokenizer,
+        model_forward: Optional[Callable] = None,
         max_seq_length: Optional[int] = None,
         device="cpu",
     ):
         super().__init__(device=device)
         self._model = model
+        self._model_forward = (
+            model_forward
+            if model_forward is not None
+            else lambda x, input_pos: model(x, input_pos)
+        )
         self._tokenizer = tokenizer
         self._device = torch.device(device)
         self._max_seq_length = 2048 if max_seq_length is None else max_seq_length
@@ -116,11 +120,8 @@ class GPTFastEvalWrapper(eval_wrapper):
         return self._device
 
     def tok_encode(self, string: str, **kwargs):
-        encoded = encode_tokens(self._tokenizer, string, bos=True, device=self._device)
-        # encoded is a pytorch tensor, but some internal logic in the
-        # eval harness expects it to be a list instead
-        # TODO: verify this for multi-batch as well
-        encoded = encoded.tolist()
+        bos_id = self._tokenizer.bos_id()
+        encoded = [bos_id] + self._tokenizer.encode(string)
         return encoded
 
     def tok_decode(self, tokens):
@@ -142,7 +143,7 @@ class GPTFastEvalWrapper(eval_wrapper):
         )
         x = seq.index_select(0, input_pos).view(1, -1)
         with measure_time(message=None) as measure:
-            logits = model_forward(self._model, x, input_pos)
+            logits = self._model_forward(x, input_pos)
         self.times.append(measure.get_time())
         return logits
 
@@ -153,6 +154,7 @@ class GPTFastEvalWrapper(eval_wrapper):
 @torch.no_grad()
 def eval(
     model: Transformer,
+    model_forward: Callable,
     tokenizer,
     tasks: Optional[list] = None,
     limit: Optional[int] = None,
@@ -176,7 +178,11 @@ def eval(
         tasks = ["wikitext"]
 
     model_eval_wrapper = GPTFastEvalWrapper(
-        model, tokenizer, max_seq_length, device=device
+        model,
+        tokenizer,
+        model_forward=model_forward,
+        max_seq_length=max_seq_length,
+        device=device,
     )
 
     try:
@@ -231,11 +237,12 @@ def main(args) -> None:
     )
     tokenizer_args.validate_model(model)
 
+    model_forward = lambda x, input_pos: model(x, input_pos)  # noqa
+
     if compile:
         assert not (
             builder_args.dso_path or builder_args.pte_path
         ), "cannot compile exported model"
-        global model_forward
         model_forward = torch.compile(
             model_forward, mode="reduce-overhead", dynamic=True, fullgraph=True
         )
@@ -244,6 +251,7 @@ def main(args) -> None:
     with measure_time("Time to run eval: {time:.02f}s."):
         result = eval(
             model.to(device),
+            model_forward,
             tokenizer,
             tasks,
             limit,

--- a/generate.py
+++ b/generate.py
@@ -7,7 +7,7 @@ import argparse
 import itertools
 import logging
 import os
-import sys
+import textwrap
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -25,7 +25,8 @@ from build.builder import (
 )
 from build.model import Transformer
 from build.utils import device_sync, set_precision
-from cli import add_arguments_for_verb, arg_init, check_args, logger
+from cli import add_arguments_for_verb, arg_init, check_args
+from utils.device_info import get_device_info
 
 B_INST, E_INST = "[INST]", "[/INST]"
 B_SYS, E_SYS = "<<SYS>>", "<</SYS>>"
@@ -122,674 +123,710 @@ class GeneratorArgs:
         )
 
 
-torch._inductor.config.coordinate_descent_tuning = True
-torch._inductor.config.triton.unique_kernel_names = True
-torch._inductor.config.fx_graph_cache = True  # Experimental feature to reduce compilation times, will be on by default in future
+class Generator:
+    """
+    Generates text samples based on a pre-trained Transformer model and tokenizer.
+    Args:
+        builder_args: Defines the model configuration
+        speculative_builder_args: Defines the speculative model configuration for speculative decode
+        tokenizer_args: Defines the tokenizer configuration for both the model and speculative model
+        generator_args: Controls the generation parameters
+        profile: A Path to a directory where the profiling results will be stored, if enabled.
+        quantize: If True, quantize the model.
+        draft_quantize: If True, quantize the draft model.
+    """
 
+    def __init__(
+        self,
+        builder_args: BuilderArgs,
+        speculative_builder_args: BuilderArgs,
+        tokenizer_args: TokenizerArgs,
+        generator_args: GeneratorArgs,
+        profile: Optional[Path],
+        quantize: bool,
+        draft_quantize: bool,
+    ):
+        torch._inductor.config.coordinate_descent_tuning = True
+        torch._inductor.config.triton.unique_kernel_names = True
+        torch._inductor.config.fx_graph_cache = True  # Experimental feature to reduce compilation times, will be on by default in future
 
-# support running without installing as a package
-wd = Path(__file__).parent.parent.resolve()
-sys.path.append(str(wd))
+        self.builder_args = builder_args
+        self.speculative_builder_args = speculative_builder_args
+        self.tokenizer_args = tokenizer_args
+        self.profile = profile
+        self.quantize = quantize
+        self.draft_quantize = draft_quantize
 
+        # global print
+        #    from tp import maybe_init_dist
+        #    rank = maybe_init_dist()
+        # use_tp = False
+        self.rank: Optional[int] = None
+        #    if use_tp:
+        #        if rank != 0:
+        #            # only print on rank 0
+        #            print = lambda *args, **kwargs: None
 
-def multinomial_sample_one_no_sync(
-    probs_sort,
-):  # Does multinomial sampling without a cuda synchronization
-    q = torch.empty_like(probs_sort).exponential_(1)
-    return torch.argmax(probs_sort / q, dim=-1, keepdim=True).to(dtype=torch.int)
+        print(
+            f"Using device={self.builder_args.device} {get_device_info(self.builder_args.device)}"
+        )
+        set_precision(self.builder_args.precision)
+        if builder_args.use_distributed:
+            device = torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}")
+            torch.cuda.set_device(device)
+        self.is_speculative = self.speculative_builder_args.checkpoint_path is not None
 
+        if generator_args.chat_mode and not self.builder_args.is_chat_model:
+            # fmt: off
+            print(textwrap.dedent(
+                """
+                *******************************************************
+                This model is not known to support the chat function
+                and may produce nonsensical or false output.
+                *******************************************************
+                """
+            ))
+            # fmt: on
+            # raise RuntimeError("You need to use --is-chat-model to indicate model has chat support.")
 
-def logits_to_probs(logits, temperature: float = 1.0, top_k: Optional[int] = None):
-    logits = logits / max(temperature, 1e-5 if logits.dtype != torch.float16 else 1e-3)
+        self.tokenizer = _initialize_tokenizer(self.tokenizer_args)
 
-    if top_k is not None:
-        v, _ = torch.topk(logits, min(top_k, logits.size(-1)))
-        pivot = v.select(-1, -1).unsqueeze(-1)
-        logits = torch.where(logits < pivot, -float("Inf"), logits)
-    probs = torch.nn.functional.softmax(logits, dim=-1)
-    return probs
-
-
-def sample(
-    logits, need_probs: bool, temperature: float = 1.0, top_k: Optional[int] = None
-):
-    if temperature == 0 and not need_probs:
-        _, idx_next = torch.topk(logits[0, -1], k=1, dim=-1)
-        return (idx_next, None)
-    probs = logits_to_probs(logits[0, -1], temperature, top_k)
-    idx_next = multinomial_sample_one_no_sync(probs)
-    return idx_next, probs
-
-
-def prefill(
-    model: Transformer,
-    x: torch.Tensor,
-    input_pos: torch.Tensor,
-    *,
-    sequential_prefill=True,
-    **sampling_kwargs,
-) -> torch.Tensor:
-    # logging.debug(f"x: {x}, input_pos: {input_pos}")
-    width = x.size(1)
-    assert input_pos.size(0) == width
-
-    if sequential_prefill:
-        for i in range(width):
-            x_sliced, ip_sliced = x[:, i].view(-1, 1), input_pos[i].view(-1)
-            # logging.debug(f"<sliced> x: {x_sliced}, input_pos: {ip_sliced}")
-            logits = model(x_sliced, ip_sliced)  # (x[:, i], input_pos[i])
-    else:
-        # input_pos: [B, S]
-        logits = model(x, input_pos)
-        # print(f"logits {logits.shape}")
-
-    # print(f"x: {x},\n  input_pos: {input_pos}\n")
-    return sample(logits, need_probs=False, **sampling_kwargs)[0]
-
-
-def decode_one_token(
-    model: Transformer,
-    x: torch.Tensor,
-    input_pos: torch.Tensor,
-    need_probs: bool,
-    **sampling_kwargs,
-) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
-    # input_pos: [B, 1]
-    assert input_pos.shape[-1] == 1
-    logits = model(x, input_pos)
-    # print(f"x: {x},\n  input_pos: {input_pos}\n")
-    return sample(logits, need_probs=need_probs, **sampling_kwargs)
-
-
-def decode_n_tokens(
-    model: Transformer,
-    cur_token: torch.Tensor,
-    input_pos: torch.Tensor,
-    num_new_tokens: int,
-    need_probs: bool,
-    callback=lambda _: _,
-    eos_token_id: int = 2,
-    eot_id: Optional[int] = None,
-    **sampling_kwargs,
-):
-    new_tokens, new_probs = [], []
-    encountered_eos = False
-    for _i in range(
-        num_new_tokens - 1
-    ):  # -1 to save space to run an EoS if dont generate it naturally
-        # Actually better for Inductor to codegen attention here
-        with torch.nn.attention.sdpa_kernel([torch.nn.attention.SDPBackend.MATH]):
-            next_token, next_prob = decode_one_token(
-                model,
-                cur_token.clone(),
-                input_pos,
-                need_probs=need_probs,
-                **sampling_kwargs,
+        # Right now the assumption is only llama3 uses tiktokenizer and it
+        # must use tiktokenizer.
+        # Piggy backing off of this flag then for now to identify llama3
+        # without prompting user.
+        self.is_llama3_model = self.tokenizer_args.is_tiktoken
+        if generator_args.chat_mode and self.is_llama3_model:
+            logging.debug(
+                "Llama3 model detected in chat mode. Using updated sentence schemas"
             )
-            input_pos += 1
-            new_tokens.append(next_token.clone())
-            callback(new_tokens[-1], done_generating=_i == num_new_tokens - 2)
-            if need_probs:
-                new_probs.append(next_prob.clone())
-            cur_token = next_token.view(1, -1)
-            # encountered eos
-            if next_token.item() == eos_token_id or (
-                eot_id is not None and next_token.item() == eot_id
-            ):
-                encountered_eos = True
-                _, _ = decode_one_token(
-                    model, cur_token, input_pos, need_probs, **sampling_kwargs
+
+        self.builder_args.setup_caches = False
+        self.model = _initialize_model(self.builder_args, self.quantize, self.tokenizer)
+
+        if self.is_speculative:
+            self.draft_model = _initialize_model(
+                self.speculative_builder_args,
+                (
+                    self.quantize
+                    if self.draft_quantize == "quantize"
+                    else self.draft_quantize
+                ),
+                self.tokenizer,
+            )
+        else:
+            self.draft_model = None
+
+        self.tokenizer_args.validate_model(self.model)
+        self.tokenizer_args.validate_model(self.draft_model, "draft model")
+        generator_args.validate_build(self.builder_args)
+        generator_args.validate_build(self.speculative_builder_args, "draft model")
+
+    def multinomial_sample_one_no_sync(
+        self,
+        probs_sort,
+    ):  # Does multinomial sampling without a cuda synchronization
+        q = torch.empty_like(probs_sort).exponential_(1)
+        return torch.argmax(probs_sort / q, dim=-1, keepdim=True).to(dtype=torch.int)
+
+    def logits_to_probs(
+        self, logits, temperature: float = 1.0, top_k: Optional[int] = None
+    ):
+        logits = logits / max(
+            temperature, 1e-5 if logits.dtype != torch.float16 else 1e-3
+        )
+
+        if top_k is not None:
+            v, _ = torch.topk(logits, min(top_k, logits.size(-1)))
+            pivot = v.select(-1, -1).unsqueeze(-1)
+            logits = torch.where(logits < pivot, -float("Inf"), logits)
+        probs = torch.nn.functional.softmax(logits, dim=-1)
+        return probs
+
+    def sample(
+        self,
+        logits,
+        need_probs: bool,
+        temperature: float = 1.0,
+        top_k: Optional[int] = None,
+    ):
+        if temperature == 0 and not need_probs:
+            _, idx_next = torch.topk(logits[0, -1], k=1, dim=-1)
+            return (idx_next, None)
+        probs = self.logits_to_probs(logits[0, -1], temperature, top_k)
+        idx_next = self.multinomial_sample_one_no_sync(probs)
+        return idx_next, probs
+
+    def prefill(
+        self,
+        model: Transformer,
+        x: torch.Tensor,
+        input_pos: torch.Tensor,
+        *,
+        sequential_prefill=True,
+        **sampling_kwargs,
+    ) -> torch.Tensor:
+        # logging.debug(f"x: {x}, input_pos: {input_pos}")
+        width = x.size(1)
+        assert input_pos.size(0) == width
+
+        if sequential_prefill:
+            for i in range(width):
+                x_sliced, ip_sliced = x[:, i].view(-1, 1), input_pos[i].view(-1)
+                # logging.debug(f"<sliced> x: {x_sliced}, input_pos: {ip_sliced}")
+                logits = model(x_sliced, ip_sliced)  # (x[:, i], input_pos[i])
+        else:
+            # input_pos: [B, S]
+            logits = model(x, input_pos)
+            # print(f"logits {logits.shape}")
+
+        # print(f"x: {x},\n  input_pos: {input_pos}\n")
+        return self.sample(logits, need_probs=False, **sampling_kwargs)[0]
+
+    def decode_one_token(
+        self,
+        model: Transformer,
+        x: torch.Tensor,
+        input_pos: torch.Tensor,
+        need_probs: bool,
+        **sampling_kwargs,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        # input_pos: [B, 1]
+        assert input_pos.shape[-1] == 1
+        logits = model(x.view(1, -1), input_pos)
+        # print(f"x: {x},\n  input_pos: {input_pos}\n")
+        return self.sample(logits, need_probs=need_probs, **sampling_kwargs)
+
+    """
+    Decode the next n tokens.
+
+    Yields a tuple of (token, prob) for each token.
+    """
+
+    def decode_n_tokens(
+        self,
+        model: Transformer,
+        cur_token: torch.Tensor,
+        input_pos: torch.Tensor,
+        num_new_tokens: int,
+        need_probs: bool,
+        callback=lambda _: _,
+        eos_token_id: int = 2,
+        eot_id: Optional[int] = None,
+        **sampling_kwargs,
+    ):
+        new_tokens, new_probs = [], []
+        encountered_eos = False
+        for _i in range(
+            num_new_tokens - 1
+        ):  # -1 to save space to run an EoS if dont generate it naturally
+            # Actually better for Inductor to codegen attention here
+            with torch.nn.attention.sdpa_kernel([torch.nn.attention.SDPBackend.MATH]):
+
+                out_token = cur_token.clone()
+                next_token, next_prob = self.decode_one_token(
+                    model,
+                    out_token,
+                    input_pos,
+                    need_probs=need_probs,
+                    **sampling_kwargs,
                 )
                 input_pos += 1
-                break
-    if not encountered_eos:
-        eos_token = torch.tensor(
-            [eos_token_id if eot_id is None else eot_id],
-            dtype=cur_token.dtype,
-            device=cur_token.device,
-        )
-        new_tokens.append(eos_token.clone())
-        _, _ = decode_one_token(
-            model, eos_token.view(1, -1), input_pos, need_probs, **sampling_kwargs
-        )
-        input_pos += 1
+                new_tokens.append(next_token.clone())
+                callback(new_tokens[-1], done_generating=_i == num_new_tokens - 2)
+                if need_probs or next_prob is None:
+                    yield out_token, None
+                else:
+                    new_probs.append(next_prob.clone())
+                    yield out_token, next_prob.clone()
+                cur_token = next_token
 
-    return new_tokens, new_probs
+                # encountered eos
+                if next_token.item() == eos_token_id or (
+                    eot_id is not None and next_token.item() == eot_id
+                ):
+                    encountered_eos = True
+                    final_token, next_prob = self.decode_one_token(
+                        model, cur_token, input_pos, need_probs, **sampling_kwargs
+                    )
+                    input_pos += 1
+                    break
 
+        if not encountered_eos:
+            eos_token = torch.tensor(
+                [eos_token_id if eot_id is None else eot_id],
+                dtype=cur_token.dtype,
+                device=cur_token.device,
+            )
+            new_tokens.append(eos_token.clone())
+            eos_token, next_prob = self.decode_one_token(
+                model, eos_token.view(1, -1), input_pos, need_probs, **sampling_kwargs
+            )
+            input_pos += 1
+            yield eos_token.clone(), (
+                next_prob.clone() if next_prob is not None else None
+            )
 
-def model_forward(model, x, input_pos):
-    return model(x, input_pos)
+        # return new_tokens, new_probs
 
+    def model_forward(self, model, x, input_pos):
+        return model(x, input_pos)
 
-def speculative_decode(
-    model: Transformer,
-    draft_model: Transformer,
-    cur_token: torch.Tensor,
-    input_pos: int,
-    speculate_k: int,
-    **sampling_kwargs,
-) -> torch.Tensor:
-    # draft model inference sequentially
-    device = cur_token.device
-    orig_input_pos = torch.tensor(
-        [input_pos], dtype=torch.int64, device=cur_token.device
-    )
-    draft_tokens, draft_probs = decode_n_tokens(
-        draft_model,
-        cur_token.view(1, -1),
-        orig_input_pos.clone(),
-        speculate_k,
-        need_probs=True,
+    def speculative_decode(
+        self,
+        model: Transformer,
+        draft_model: Transformer,
+        cur_token: torch.Tensor,
+        input_pos: int,
+        speculate_k: int,
         **sampling_kwargs,
-    )
-
-    draft_tokens = torch.cat(draft_tokens)
-    # parallel inference on target model using draft tokens
-    target_logits = model_forward(
-        model,
-        torch.cat([cur_token.view(1), draft_tokens]).view(1, -1),
-        torch.arange(input_pos, input_pos + speculate_k + 1, device=cur_token.device),
-    )
-    target_probs = logits_to_probs(target_logits[0], **sampling_kwargs)
-    draft_probs = torch.stack(draft_probs)
-    # q: target prob, p: draft prob
-    # q >= p: always accept draft token
-    # q < p: q/p prob to accept draft token
-    p = draft_probs[torch.arange(0, speculate_k, device=device), draft_tokens]
-    q = target_probs[torch.arange(0, speculate_k, device=device), draft_tokens]
-    accept_draft_prob = torch.minimum(torch.ones(()), q[:speculate_k] / p)
-    rejected_locations = (
-        torch.rand_like(accept_draft_prob) > accept_draft_prob
-    ).nonzero()
-
-    if rejected_locations.shape[0] == 0:  # All draft tokens have been accepted
-        accept_length = speculate_k + 1
-        last_token = multinomial_sample_one_no_sync(target_probs[-1])
-        # fill last token into draft model
-        model_forward(
-            draft_model,
-            draft_tokens[-1].view(1, -1),
-            orig_input_pos + speculate_k,
+    ) -> torch.Tensor:
+        # draft model inference sequentially
+        device = cur_token.device
+        orig_input_pos = torch.tensor(
+            [input_pos], dtype=torch.int64, device=cur_token.device
         )
-        return torch.cat([draft_tokens, last_token])
-    else:
-        accept_length = rejected_locations[0].item()
-        p = draft_probs[accept_length]
-        q = target_probs[accept_length]
-        new = q - p
-        new = torch.where(new > 0, new, 0.0)
-        new = new / new.sum()
-        next_token = multinomial_sample_one_no_sync(new)
-        return torch.cat([draft_tokens[:accept_length], next_token])
-
-
-@torch.no_grad()
-def generate(
-    model: Transformer,
-    prompt: torch.Tensor,
-    max_new_tokens: int,
-    *,
-    chat_mode: bool,
-    start_pos: int = 0,
-    draft_model: Transformer,
-    speculate_k: Optional[int] = 8,
-    sequential_prefill=True,
-    callback=lambda x: x,
-    tokenizer=None,
-    max_seq_length: int,
-    is_llama3_model: bool = False,
-    **sampling_kwargs,
-) -> torch.Tensor:
-    """
-    Takes a conditioning sequence (prompt) as input and continues to generate as many tokens as requested.
-    """
-    is_speculative = draft_model is not None
-    device, dtype = prompt.device, prompt.dtype
-
-    # create an empty tensor of the expected final shape and
-    # fill in the current tokens
-    T = prompt.size(0)
-    max_new_tokens = min(max_new_tokens, max_seq_length - start_pos - T)
-    T_new = T + max_new_tokens
-    # set up caches only if first inference
-    if start_pos == 0:
-        model = model.to(device=device)
-        with torch.device(device):
-            model.setup_caches(max_batch_size=1, max_seq_length=max_seq_length)
-            if is_speculative and draft_model is not model:
-                draft_model.setup_caches(
-                    max_batch_size=1, max_seq_length=max_seq_length
-                )
-
-    # create an empty tensor of the expected final shape and
-    # fill in the current tokens
-    empty = torch.empty(T_new, dtype=dtype, device=device)
-    empty[:T] = prompt
-    seq = empty
-    input_pos = torch.arange(start_pos, T + start_pos, device=device, dtype=torch.int)
-
-    prefill_t0 = time.perf_counter()
-    next_token = prefill(
-        model,
-        prompt.view(1, -1),
-        input_pos,
-        sequential_prefill=sequential_prefill,
-        **sampling_kwargs,
-    )
-    if is_speculative:
-        prefill(
+        draft_tokens, draft_probs = self.decode_n_tokens(
             draft_model,
+            cur_token,
+            orig_input_pos.clone(),
+            speculate_k,
+            need_probs=True,
+            **sampling_kwargs,
+        )
+
+        draft_tokens = torch.cat(draft_tokens)
+        # parallel inference on target model using draft tokens
+        target_logits = self.model_forward(
+            model,
+            torch.cat([cur_token.view(1), draft_tokens]).view(1, -1),
+            torch.arange(
+                input_pos, input_pos + speculate_k + 1, device=cur_token.device
+            ),
+        )
+        target_probs = self.logits_to_probs(target_logits[0], **sampling_kwargs)
+        draft_probs = torch.stack(draft_probs)
+        # q: target prob, p: draft prob
+        # q >= p: always accept draft token
+        # q < p: q/p prob to accept draft token
+        p = draft_probs[torch.arange(0, speculate_k, device=device), draft_tokens]
+        q = target_probs[torch.arange(0, speculate_k, device=device), draft_tokens]
+        accept_draft_prob = torch.minimum(torch.ones(()), q[:speculate_k] / p)
+        rejected_locations = (
+            torch.rand_like(accept_draft_prob) > accept_draft_prob
+        ).nonzero()
+
+        if rejected_locations.shape[0] == 0:  # All draft tokens have been accepted
+            accept_length = speculate_k + 1
+            last_token = self.multinomial_sample_one_no_sync(target_probs[-1])
+            # fill last token into draft model
+            self.model_forward(
+                draft_model,
+                draft_tokens[-1].view(1, -1),
+                orig_input_pos + speculate_k,
+            )
+            return torch.cat([draft_tokens, last_token])
+        else:
+            accept_length = rejected_locations[0].item()
+            p = draft_probs[accept_length]
+            q = target_probs[accept_length]
+            new = q - p
+            new = torch.where(new > 0, new, 0.0)
+            new = new / new.sum()
+            next_token = self.multinomial_sample_one_no_sync(new)
+            return torch.cat([draft_tokens[:accept_length], next_token])
+
+    @torch.no_grad()
+    def generate(
+        self,
+        model: Transformer,
+        prompt: torch.Tensor,
+        max_new_tokens: int,
+        *,
+        chat_mode: bool,
+        start_pos: int = 0,
+        draft_model: Transformer,
+        speculate_k: Optional[int] = 8,
+        sequential_prefill=True,
+        callback=lambda x: x,
+        max_seq_length: int,
+        **sampling_kwargs,
+    ) -> torch.Tensor:
+        """
+        Takes a conditioning sequence (prompt) as input and continues to generate as many tokens as requested.
+        """
+        is_speculative = draft_model is not None
+        device, dtype = prompt.device, prompt.dtype
+
+        # create an empty tensor of the expected final shape and
+        # fill in the current tokens
+        T = prompt.size(0)
+        max_new_tokens = min(max_new_tokens, max_seq_length - start_pos - T)
+        T_new = T + max_new_tokens
+        # set up caches only if first inference
+        if start_pos == 0:
+            model = model.to(device=device)
+            with torch.device(device):
+                model.setup_caches(max_batch_size=1, max_seq_length=max_seq_length)
+                if is_speculative and draft_model is not model:
+                    draft_model.setup_caches(
+                        max_batch_size=1, max_seq_length=max_seq_length
+                    )
+
+        # create an empty tensor of the expected final shape and
+        # fill in the current tokens
+        empty = torch.empty(T_new, dtype=dtype, device=device)
+        empty[:T] = prompt
+        seq = empty
+        input_pos = torch.arange(
+            start_pos, T + start_pos, device=device, dtype=torch.int
+        )
+
+        prefill_t0 = time.perf_counter()
+        next_token = self.prefill(
+            model,
             prompt.view(1, -1),
             input_pos,
             sequential_prefill=sequential_prefill,
             **sampling_kwargs,
         )
-    time_to_first_token = time.perf_counter() - prefill_t0
-    seq[T] = next_token
-    # max_new_tokens <= 2 means we are effectively not calling decode_n_tokens().
-    callback(next_token.clone().view(-1), done_generating=max_new_tokens <= 2)
-
-    num_tokens_generated = 0
-    input_pos = torch.tensor([start_pos + T], device=device, dtype=torch.int)
-    accept_counts = [0] * (
-        speculate_k + 1
-    )  # creates array of [0, 0, 0, ...] that is speculate_k + 1 long
-
-    if is_speculative:
-        input_pos = input_pos.item()  # for speculative decoding easier to keep on host
-        while input_pos < max_new_tokens - 1:
-            cur_token = next_token.view(())
-
-            next_tokens = speculative_decode(
-                model, draft_model, cur_token, input_pos, speculate_k, **sampling_kwargs
+        if is_speculative:
+            self.prefill(
+                draft_model,
+                prompt.view(1, -1),
+                input_pos,
+                sequential_prefill=sequential_prefill,
+                **sampling_kwargs,
             )
+        time_to_first_token = time.perf_counter() - prefill_t0
+        seq[T] = next_token
+        # max_new_tokens <= 2 means we are effectively not calling decode_n_tokens().
+        callback(next_token.clone().view(-1), done_generating=max_new_tokens <= 2)
 
-            accept_counts[len(next_tokens) - 1] += 1
-            num_added = min(T_new - input_pos - 1, len(next_tokens))
-            seq[input_pos + 1 : input_pos + num_added + 1] = next_tokens[:num_added]
-            for i in next_tokens[:num_added,]:
-                callback(i)
-            input_pos = input_pos + num_added
-            next_token = next_tokens[-1]
-    else:
-        generated_tokens, _ = decode_n_tokens(
-            model,
-            next_token.view(1, -1),
-            input_pos,
-            max_new_tokens - 1,
-            callback=callback,
-            need_probs=False,
-            eos_token_id=tokenizer.eos_id() if tokenizer else 2,
-            eot_id=tokenizer.special_tokens["<|eot_id|>"] if is_llama3_model else None,
-            **sampling_kwargs,
-        )
-        seq[T + 1 : T + 1 + len(generated_tokens)] = torch.cat(generated_tokens)
-        seq = seq[
-            : T + 1 + len(generated_tokens)
-        ]  # If we dont generate all the way to max_new_tokens slice off the extra space we allocated.
-
-    generate_stats = {
-        "accept_counts": accept_counts,
-        "time_to_first_token": time_to_first_token,
-    }
-    return seq, generate_stats
-
-
-def encode_tokens(tokenizer, string, bos=True, device="cpu"):
-    tokens = tokenizer.encode(string)
-    if bos:
-        tokens = [tokenizer.bos_id()] + tokens
-    return torch.tensor(tokens, dtype=torch.int, device=device)
-
-
-def get_device_info(name: str) -> str:
-    import platform
-    from subprocess import check_output
-
-    if name == "cpu":
-        if platform.system() == "Darwin":
-            return (
-                check_output(["sysctl", "-n", "machdep.cpu.brand_string"])
-                .decode("utf-8")
-                .strip()
-            )
-        if platform.system() == "Linux":
-            return (
-                check_output(
-                    ["sed", "-nr", "s/^model name\\s+: (.*)$/\\1/p", "/proc/cpuinfo"]
-                )
-                .decode("utf-8")
-                .split("\n")[0]
-            )
-    if name == "cuda":
-        return torch.cuda.get_device_name(0)
-    return ""
-
-
-def _callback(x, *, buffer, period_id, done_generating, tokenizer, is_llama3_model):
-    buffer.append(
-        tokenizer.decode([period_id] + x.tolist())[1:]
-    )  # I think this results in the first output token being dropped from the display which is wrong.
-    if x.item() == tokenizer.eos_id():
-        done_generating = True
-    if is_llama3_model and x.item() == tokenizer.special_tokens["<|eot_id|>"]:
-        done_generating = True
-        buffer = buffer[:-1]  # drop the eot_id from the output buffer
-    if len(buffer) == 4 or done_generating:
-        print("".join(buffer), end="", flush=True)
-        buffer.clear()
-    # print(, end='', flush=True)
-
-
-def _main(
-    builder_args: BuilderArgs,
-    speculative_builder_args: BuilderArgs,
-    tokenizer_args: TokenizerArgs,
-    generator_args: GeneratorArgs,
-    profile: Optional[Path],
-    quantize,
-    draft_quantize,
-) -> None:
-    """
-    Generates text samples based on a pre-trained Transformer model and tokenizer.
-    """
-
-    # global print
-    #    from tp import maybe_init_dist
-    #    rank = maybe_init_dist()
-    use_tp = False
-    rank: Optional[int] = None
-    #    if use_tp:
-    #        if rank != 0:
-    #            # only print on rank 0
-    #            print = lambda *args, **kwargs: None
-
-    print(f"Using device={builder_args.device} {get_device_info(builder_args.device)}")
-    # If using distributed inference we cannot just assign device to be cuda
-    # because it will be assigned to cuda:0 by default. We need explicitely set
-    # the device to be the local rank.
-    if builder_args.use_distributed:
-        device = torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}")
-        torch.cuda.set_device(device)
-    set_precision(builder_args.precision)
-    is_speculative = speculative_builder_args.checkpoint_path is not None
-
-    if generator_args.chat_mode and not builder_args.is_chat_model:
-        print(
-            """
-*******************************************************
- This model is not known to support the chat function.
- We will enable chat mode based on your instructions.
- If the model is not trained to support chat, it will
- produce nonsensical or false output.
-*******************************************************
-        """
-        )
-        # raise RuntimeError("You need to use --is-chat-model to indicate model has chat support.")
-
-    tokenizer = _initialize_tokenizer(tokenizer_args)
-
-    # Right now the assumption is only llama3 uses tiktokenizer and it
-    # must use tiktokenizer.
-    # Piggy backing off of this flag then for now to identify llama3
-    # without prompting user.
-    is_llama3_model = tokenizer_args.is_tiktoken
-    if generator_args.chat_mode and is_llama3_model:
-        logging.debug(
-            "Llama3 model detected in chat mode. Using updated sentence schemas"
-        )
-
-    builder_args.setup_caches = False
-    model = _initialize_model(builder_args, quantize, tokenizer)
-
-    if is_speculative:
-        draft_model = _initialize_model(
-            speculative_builder_args,
-            quantize if draft_quantize == "quantize" else draft_quantize,
-            tokenizer,
-        )
-    else:
-        draft_model = None
-
-    tokenizer_args.validate_model(model)
-    tokenizer_args.validate_model(draft_model, "draft model")
-    generator_args.validate_build(builder_args)
-    generator_args.validate_build(speculative_builder_args, "draft model")
-
-    encoded = encode_tokens(
-        tokenizer, generator_args.prompt, bos=True, device=builder_args.device
-    )
-    logging.debug(encoded)
-    prompt_length = encoded.size(0)
-
-    model_size = sum(
-        [
-            p.numel() * p.dtype.itemsize
-            for p in itertools.chain(model.parameters(), model.buffers())
-        ]
-    )
-    if generator_args.compile:
-        if (
-            is_speculative and builder_args.use_tp
-        ):  # and ("cuda" in builder_args.device):
-            torch._inductor.config.triton.cudagraph_trees = (
-                False  # Bug with cudagraph trees in this case
-            )
+        input_pos = torch.tensor([start_pos + T], device=device, dtype=torch.int)
+        accept_counts = [0] * (
+            speculate_k + 1
+        )  # creates array of [0, 0, 0, ...] that is speculate_k + 1 long
 
         if is_speculative:
-            global model_forward, logits_to_prob
-            model_forward = torch.compile(
-                model_forward, mode="reduce-overhead", fullgraph=True
-            )
+            input_pos = (
+                input_pos.item()
+            )  # for speculative decoding easier to keep on host
+            while input_pos < max_new_tokens - 1:
+                cur_token = next_token.view(())
 
-        global decode_one_token, prefill
-        decode_one_token = torch.compile(
-            decode_one_token, mode="reduce-overhead", fullgraph=True
-        )
-
-        if generator_args.compile_prefill:
-            prefill = torch.compile(prefill, fullgraph=True, dynamic=True)
-
-    system_prompt = None
-    # Set up our max_seq_length
-    if generator_args.chat_mode:
-        max_seq_length = model.config.max_seq_length
-        print(
-            f"Entering Chat Mode. Will continue chatting back and forth with the language model until the models max context length of {max_seq_length} tokens is hit or until the user says /bye"
-        )
-        get_system_prompt = input(
-            "Do you want to enter a system prompt? Enter y for yes and anything else for no. \n"
-        )
-        if get_system_prompt == "y" or get_system_prompt == "Y":
-            system_prompt = input("What is your system prompt? \n")
-        if is_llama3_model:
-            chat_formatter = ChatFormat(tokenizer)
-    else:
-        max_seq_length = min(
-            encoded.size(0) + generator_args.max_new_tokens, model.config.block_size
-        )
-
-    max_seq_length = (
-        max_seq_length + speculative_builder_args.speculate_k + 1
-        if draft_model is not None
-        else max_seq_length
-    )
-
-    aggregate_metrics = {
-        "tokens_per_sec": [],
-        "accept_counts": [],
-    }
-    start = -1 if generator_args.compile else 0
-    start_pos = 0
-
-    # arbitrarily large number as chat mode goes until max_seq length
-    # or user exits
-    num_samples = generator_args.num_samples if not generator_args.chat_mode else 100000
-    for i in range(num_samples):
-        device_sync(device=builder_args.device)
-        if i >= 0 and generator_args.chat_mode:
-            prompt = input("User: ")
-            if prompt == "/bye":
-                print("Exiting Chat.\n")
-                break
-            if not is_llama3_model:
-                if system_prompt:
-                    prompt = f"{B_INST} {B_SYS}\n{system_prompt.strip()}\n{E_SYS}\n\n{prompt.strip()} {E_INST}"
-                    system_prompt = (
-                        None  # can only provide system prompt on first interaction
-                    )
-                else:
-                    prompt = f"{B_INST} {prompt.strip()} {E_INST}"
-                encoded = encode_tokens(
-                    tokenizer, prompt, bos=True, device=builder_args.device
-                )
-            else:
-                if system_prompt is not None:
-                    encoded = chat_formatter.encode_dialog_prompt(
-                        [
-                            {"role": "system", "content": system_prompt},
-                            {"role": "user", "content": prompt},
-                        ]
-                    )
-                    system_prompt = None
-                elif i == 0:
-                    encoded = chat_formatter.encode_dialog_prompt(
-                        [{"role": "user", "content": prompt}]
-                    )
-                else:
-                    encoded = chat_formatter.encode_message(
-                        {"role": "user", "content": prompt}
-                    )
-                    encoded.extend(
-                        chat_formatter.encode_header(
-                            {"role": "assistant", "content": ""}
-                        )
-                    )
-                encoded = torch.tensor(
-                    encoded, dtype=torch.int, device=builder_args.device
-                )
-            if encoded.size(0) + start_pos > max_seq_length:
-                print(
-                    "This prompt would take us past the max_seq_length. Ending Conversation."
-                )
-                break
-
-        if generator_args.chat_mode and i >= 0:
-            print("Model: ", end="")
-
-            buffer = []
-            period_id = tokenizer.encode(".")[0]
-
-            def callback(x, *, done_generating=False):
-                return _callback(
-                    x,
-                    buffer=buffer,
-                    period_id=period_id,
-                    done_generating=done_generating,
-                    tokenizer=tokenizer,
-                    is_llama3_model=is_llama3_model,
+                next_tokens = self.speculative_decode(
+                    model,
+                    draft_model,
+                    cur_token,
+                    input_pos,
+                    speculate_k,
+                    **sampling_kwargs,
                 )
 
+                accept_counts[len(next_tokens) - 1] += 1
+                num_added = min(T_new - input_pos - 1, len(next_tokens))
+                seq[input_pos + 1 : input_pos + num_added + 1] = next_tokens[:num_added]
+                for i in next_tokens[:num_added,]:
+                    callback(i)
+                    yield i, {}
+                input_pos = input_pos + num_added
+                next_token = next_tokens[-1]
         else:
-            assert not generator_args.chat_mode
-            buffer = [generator_args.prompt]
-            period_id = tokenizer.encode(".")[0]
-
-            def callback(x, *, done_generating=False):
-                return _callback(
-                    x,
-                    buffer=buffer,
-                    period_id=period_id,
-                    done_generating=done_generating,
-                    tokenizer=tokenizer,
-                    is_llama3_model=is_llama3_model,
-                )
-
-        if (i != generator_args.num_samples - 1 or not profile) or (
-            use_tp and rank != 0
-        ):
-            import contextlib
-
-            prof = contextlib.nullcontext()
-        else:
-            torch.profiler._utils._init_for_cuda_graphs()
-            prof = torch.profiler.profile()
-        t0 = time.perf_counter()
-        with prof:
-            y, metrics = generate(
+            generated_tokens = []
+            for generated_token, _ in self.decode_n_tokens(
                 model,
-                encoded,
-                generator_args.max_new_tokens,
-                draft_model=draft_model,
-                speculate_k=generator_args.speculate_k,
-                chat_mode=generator_args.chat_mode,
+                next_token,
+                input_pos,
+                max_new_tokens - 1,
                 callback=callback,
-                temperature=generator_args.temperature,
-                top_k=generator_args.top_k,
-                sequential_prefill=generator_args.sequential_prefill,
-                start_pos=start_pos,
-                tokenizer=tokenizer,
-                max_seq_length=max_seq_length,
-                is_llama3_model=is_llama3_model,
-            )
-            aggregate_metrics["accept_counts"].append(metrics["accept_counts"])
-            start_pos += y.size(0)
-        jit_compile = (i == 0) and (
-            generator_args.compile or generator_args.compile_prefill
+                need_probs=False,
+                eos_token_id=self.tokenizer.eos_id() if self.tokenizer else 2,
+                eot_id=(
+                    self.tokenizer.special_tokens["<|eot_id|>"]
+                    if self.is_llama3_model
+                    else None
+                ),
+                **sampling_kwargs,
+            ):
+                generated_tokens.append(generated_token)
+                yield generated_token, {}
+
+            seq[T + 1 : T + 1 + len(generated_tokens)] = torch.cat(generated_tokens)
+            seq = seq[
+                : T + 1 + len(generated_tokens)
+            ]  # If we dont generate all the way to max_new_tokens slice off the extra space we allocated.
+
+        generate_stats = {
+            "accept_counts": accept_counts,
+            "time_to_first_token": time_to_first_token,
+        }
+        return seq, generate_stats
+
+    def encode_tokens(self, string, bos=True, device="cpu"):
+        tokens = self.tokenizer.encode(string)
+        if bos:
+            tokens = [self.tokenizer.bos_id()] + tokens
+        return torch.tensor(tokens, dtype=torch.int, device=device)
+
+    def _callback(self, x, *, buffer, done_generating):
+        # TODO: Refactor this callback to only include basic functionality & remove print statements
+        period_id = self.tokenizer.encode(".")[0]
+        buffer.append(
+            self.tokenizer.decode([period_id] + x.tolist())[1:]
+        )  # I think this results in the first output token being dropped from the display which is wrong.
+        if x.item() == self.tokenizer.eos_id():
+            done_generating = True
+        if (
+            self.is_llama3_model
+            and x.item() == self.tokenizer.special_tokens["<|eot_id|>"]
+        ):
+            done_generating = True
+            buffer = buffer[:-1]  # drop the eot_id from the output buffer
+        if len(buffer) == 4 or done_generating:
+            print("".join(buffer), end="", flush=True)
+            buffer.clear()
+        # print(, end='', flush=True)
+
+    def chat(
+        self,
+        generator_args: GeneratorArgs,
+    ):
+        if generator_args.chat_mode:
+            print("Starting Interactive Chat")
+        encoded = self.encode_tokens(
+            generator_args.prompt, bos=True, device=self.builder_args.device
         )
-        compilation_time = time.perf_counter() - t0
-        if hasattr(prof, "export_chrome_trace"):
-            if use_tp:
-                prof.export_chrome_trace(f"{profile}_rank_{rank}.json")
-            else:
-                prof.export_chrome_trace(f"{profile}.json")
-        device_sync(device=builder_args.device)
-        t = time.perf_counter() - t0
+        logging.debug(encoded)
 
-        print()
-        if start_pos >= max_seq_length:
-            print(f"[Max Sequence Length Reached. Ending Conversation.]")
-            print(f"---------------------------------------------------")
+        model_size = sum(
+            [
+                p.numel() * p.dtype.itemsize
+                for p in itertools.chain(self.model.parameters(), self.model.buffers())
+            ]
+        )
+        if generator_args.compile:
+            if (
+                self.is_speculative and self.builder_args.use_tp
+            ):  # and ("cuda" in builder_args.device):
+                torch._inductor.config.triton.cudagraph_trees = (
+                    False  # Bug with cudagraph trees in this case
+                )
 
-        tokens_generated = y.size(0) - prompt_length
-        tokens_sec = tokens_generated / t
-        aggregate_metrics["tokens_per_sec"].append(tokens_sec)
+            if self.is_speculative:
+                self.model_forward = torch.compile(
+                    self.model_forward, mode="reduce-overhead", fullgraph=True
+                )
 
-        if jit_compile:
+            self.decode_one_token = torch.compile(
+                self.decode_one_token, mode="reduce-overhead", fullgraph=True
+            )
+
+            if generator_args.compile_prefill:
+                self.prefill = torch.compile(self.prefill, fullgraph=True, dynamic=True)
+
+        self.system_prompt = None
+        # Set up our max_seq_length
+        if generator_args.chat_mode:
+            max_seq_length = self.model.config.max_seq_length
             print(
-                f"just-in-time compilation time (incl run time): {compilation_time:.2} seconds"
+                f"Entering Chat Mode. Will continue chatting back and forth with the language model until the models max context length of {max_seq_length} tokens is hit or until the user says /bye"
             )
-            # Don't continue here.... because we need to report and reset
-            # continue
+            get_system_prompt = input(
+                "Do you want to enter a system prompt? Enter y for yes and anything else for no. \n"
+            )
+            if get_system_prompt == "y" or get_system_prompt == "Y":
+                self.system_prompt = input("What is your system prompt? \n")
+            if self.is_llama3_model:
+                self.chat_formatter = ChatFormat(self.tokenizer)
+        else:
+            max_seq_length = min(
+                encoded.size(0) + generator_args.max_new_tokens,
+                self.model.config.block_size,
+            )
 
-        logging.info(
-            f"Time for inference {i + 1}: {t:.02f} sec total, time to first token {metrics['time_to_first_token']:.02f} sec with {'sequential' if generator_args.sequential_prefill else 'parallel'} prefill, {tokens_generated} tokens, {tokens_sec:.02f} tokens/sec, {1000 / tokens_sec:.02f} ms/token"
+        max_seq_length = (
+            max_seq_length + self.speculative_builder_args.speculate_k + 1
+            if self.draft_model is not None
+            else max_seq_length
         )
-        logging.info(f"Bandwidth achieved: {model_size * tokens_sec / 1e9:.02f} GB/s")
-        if i == 0:
+
+        aggregate_metrics = {
+            "tokens_per_sec": [],
+            "accept_counts": [],
+        }
+        start_pos = 0
+
+        # arbitrarily large number as chat mode goes until max_seq length
+        # or user exits
+        num_samples = (
+            generator_args.num_samples if not generator_args.chat_mode else 100000
+        )
+        for i in range(num_samples):
+            device_sync(device=self.builder_args.device)
+            if i >= 0 and generator_args.chat_mode:
+                prompt = input("User: ")
+                if prompt == "/bye":
+                    print("Exiting Chat.\n")
+                    break
+                if not self.is_llama3_model:
+                    if self.system_prompt:
+                        prompt = f"{B_INST} {B_SYS}\n{self.system_prompt.strip()}\n{E_SYS}\n\n{prompt.strip()} {E_INST}"
+                        self.system_prompt = (
+                            None  # can only provide system prompt on first interaction
+                        )
+                    else:
+                        prompt = f"{B_INST} {prompt.strip()} {E_INST}"
+                    encoded = self.encode_tokens(
+                        prompt, bos=True, device=self.builder_args.device
+                    )
+                else:
+                    if self.system_prompt is not None:
+                        encoded = self.chat_formatter.encode_dialog_prompt(
+                            [
+                                {"role": "system", "content": self.system_prompt},
+                                {"role": "user", "content": prompt},
+                            ]
+                        )
+                        self.system_prompt = None
+                    elif i == 0:
+                        encoded = self.chat_formatter.encode_dialog_prompt(
+                            [{"role": "user", "content": prompt}]
+                        )
+                    else:
+                        encoded = self.chat_formatter.encode_message(
+                            {"role": "user", "content": prompt}
+                        )
+                        encoded.extend(
+                            self.chat_formatter.encode_header(
+                                {"role": "assistant", "content": ""}
+                            )
+                        )
+                    encoded = torch.tensor(
+                        encoded, dtype=torch.int, device=self.builder_args.device
+                    )
+                if encoded.size(0) + start_pos > max_seq_length:
+                    print(
+                        "This prompt would take us past the max_seq_length. Ending Conversation."
+                    )
+                    break
+
+            if generator_args.chat_mode and i >= 0:
+                print("Model: ", end="")
+
+                buffer = []
+                def callback(x, *, done_generating=False):
+                    return self._callback(
+                        x,
+                        buffer=buffer,
+                        done_generating=done_generating,
+                    )
+
+            else:
+                assert not generator_args.chat_mode
+
+                buffer = [generator_args.prompt]
+                def callback(x, *, done_generating=False):
+                    return self._callback(
+                        x,
+                        buffer=buffer,
+                        done_generating=done_generating,
+                    )
+
+            if (i != generator_args.num_samples - 1 or not self.profile) or (
+                self.builder_args.use_tp and self.rank != 0
+            ):
+                import contextlib
+
+                prof = contextlib.nullcontext()
+            else:
+                torch.profiler._utils._init_for_cuda_graphs()
+                prof = torch.profiler.profile()
+            t0 = time.perf_counter()
+            num_tokens_generated = 0
+            with prof:
+                for y, metrics in self.generate(
+                    self.model,
+                    encoded,
+                    generator_args.max_new_tokens,
+                    draft_model=self.draft_model,
+                    speculate_k=generator_args.speculate_k,
+                    chat_mode=generator_args.chat_mode,
+                    callback=callback,
+                    temperature=generator_args.temperature,
+                    top_k=generator_args.top_k,
+                    sequential_prefill=generator_args.sequential_prefill,
+                    start_pos=start_pos,
+                    max_seq_length=max_seq_length,
+                ):
+                    if metrics:
+                        aggregate_metrics["accept_counts"].append(
+                            metrics["accept_counts"]
+                        )
+                    start_pos += y.size(0)
+                    num_tokens_generated += y.size(0)
+                    yield y, metrics
+
+            jit_compile = (i == 0) and (
+                generator_args.compile or generator_args.compile_prefill
+            )
+            compilation_time = time.perf_counter() - t0
+            if hasattr(prof, "export_chrome_trace"):
+                if self.builder_args.use_tp:
+                    prof.export_chrome_trace(f"{self.profile}_rank_{self.rank}.json")
+                else:
+                    prof.export_chrome_trace(f"{self.profile}.json")
+            device_sync(device=self.builder_args.device)
+            t = time.perf_counter() - t0
+
+            if start_pos >= max_seq_length:
+                print(
+                    f"[Max Sequence Length {max_seq_length} Reached. Ending Conversation.]"
+                )
+                print("---------------------------------------------------")
+
+            tokens_sec = num_tokens_generated / t
+            aggregate_metrics["tokens_per_sec"].append(tokens_sec)
+
+            if jit_compile:
+                print(
+                    f"just-in-time compilation time (incl run time): {compilation_time:.2} seconds"
+                )
+                # Don't continue here.... because we need to report and reset
+                # continue
+            
             logging.info(
-                f"*** This first iteration will include cold start effects for dynamic import, hardware caches{', JIT compilation' if jit_compile else ''}. ***"
+                f"\nTime for inference {i + 1}: {t:.02f} sec total, time to first token {metrics.get('time_to_first_token', 0.0):.02f} sec with {'sequential' if generator_args.sequential_prefill else 'parallel'} prefill, {num_tokens_generated} tokens, {tokens_sec:.02f} tokens/sec, {1000 / tokens_sec:.02f} ms/token"
             )
-        if start_pos >= max_seq_length:
-            if generator_args.chat_mode:
-                break
+            logging.info(
+                f"Bandwidth achieved: {model_size * tokens_sec / 1e9:.02f} GB/s"
+            )
+            if i == 0:
+                logging.info(
+                    f"*** This first iteration will include cold start effects for dynamic import, hardware caches{', JIT compilation' if jit_compile else ''}. ***"
+                )
+            if start_pos >= max_seq_length:
+                if generator_args.chat_mode:
+                    break
 
-        if not generator_args.chat_mode:
-            start_pos = 0
+            if not generator_args.chat_mode:
+                start_pos = 0
 
-    print("\n========================================\n")
-    if is_speculative:
-        counts_aggregated = [sum(i) for i in zip(*aggregate_metrics["accept_counts"])]
-        acceptance_probs = [i / sum(counts_aggregated) for i in counts_aggregated]
-        print(f"Acceptance probs: {acceptance_probs}")
+        print("\n========================================\n")
+        if self.is_speculative:
+            counts_aggregated = [
+                sum(i) for i in zip(*aggregate_metrics["accept_counts"])
+            ]
+            acceptance_probs = [i / sum(counts_aggregated) for i in counts_aggregated]
+            print(f"Acceptance probs: {acceptance_probs}")
+            print(
+                f"Mean Accepted: {sum([idx * i for idx, i in enumerate(counts_aggregated)])/sum(counts_aggregated)}"
+            )
+
         print(
-            f"Mean Accepted: {sum([idx * i for idx, i in enumerate(counts_aggregated)])/sum(counts_aggregated)}"
+            f"Average tokens/sec: {torch.mean(torch.tensor(aggregate_metrics['tokens_per_sec'])).item():.2f}"
         )
-
-    print(
-        f"Average tokens/sec: {torch.mean(torch.tensor(aggregate_metrics['tokens_per_sec'])).item():.2f}"
-    )
-    print(f"Memory used: {torch.cuda.max_memory_reserved() / 1e9:.02f} GB")
+        print(f"Memory used: {torch.cuda.max_memory_reserved() / 1e9:.02f} GB")
 
 
 def main(args):
@@ -797,8 +834,7 @@ def main(args):
     speculative_builder_args = BuilderArgs.from_speculative_args(args)
     tokenizer_args = TokenizerArgs.from_args(args)
     generator_args = GeneratorArgs.from_args(args)
-
-    _main(
+    gen = Generator(
         builder_args,
         speculative_builder_args,
         tokenizer_args,
@@ -807,6 +843,10 @@ def main(args):
         args.quantize,
         args.draft_quantize,
     )
+    if torch.cuda.is_available():
+        torch.cuda.reset_peak_memory_stats()
+    for _ in gen.chat(generator_args):
+        pass
 
 
 if __name__ == "__main__":

--- a/utils/device_info.py
+++ b/utils/device_info.py
@@ -1,0 +1,40 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import platform
+from subprocess import check_output
+
+import torch
+
+
+def get_device_info(device: str) -> str:
+    """Returns a human-readable description of the hardware based on a torch.device.type
+
+    Args:
+        device: A torch.device.type string: one of {"cpu", "cuda"}.
+    Returns:
+        str: A human-readable description of the hardware or an empty string if the device type is unhandled.
+
+    For example, if torch.device.type == "cpu" on a MacBook Pro, this function will return "Apple M1 Pro".
+    """
+    if device == "cpu":
+        if platform.system() == "Darwin":
+            return (
+                check_output(["sysctl", "-n", "machdep.cpu.brand_string"])
+                .decode("utf-8")
+                .strip()
+            )
+        if platform.system() == "Linux":
+            return (
+                check_output(
+                    ["sed", "-nr", "s/^model name\\s+: (.*)$/\\1/p", "/proc/cpuinfo"]
+                )
+                .decode("utf-8")
+                .split("\n")[0]
+            )
+    if device == "cuda":
+        return torch.cuda.get_device_name(0)
+    return ""


### PR DESCRIPTION
This is a cherry-pick of @vmpuri's https://github.com/pytorch/torchchat/pull/906

This PR refactors the chat function in generate.py by creating a `Generator` class, removing unnecessary global variables and simplifying the code structure. Tokens and metrics are now yielded by the Generator rather than being printed directly to stdout, making it easier to re-use this code for non-CLI tools.

**Tests:**
Generate
```
python3 torchchat.py generate stories15M --prompt "Once upon a time,"

Using device=mps
Loading model...
Time to load model: 0.46 seconds
-----------------------------------------------------------
Once upon a time, there was a little girl named Lily. One day, she went to the park with her mom. They saw a big tree with lots of pears on it. Lily wanted to eat a pear, but they were too high up. She tried to jump, but she couldn't reach them.
Then, a boy came and took a pear from the tree. Lily was surprised! She thought the boy would be mean, but he was harmless and didn't mean to hurt her. She asked him if she could have a pear too. The boy said yes and gave her a pear. Lily was very happy and thanked the boy for sharing. They sat under the tree and ate the pear together. It was a good day at the park. Once upon a time, there was a little girl named Lily. She loved to play in the garden with her mommy. One day, they were planting some
Time for inference 1: 3.55 sec total, time to first token 0.00 sec with parallel prefill, 199 tokens, 56.01 tokens/sec, 17.85 ms/token
Bandwidth achieved: 2.73 GB/s
*** This first iteration will include cold start effects for dynamic import, hardware caches. ***

========================================

Average tokens/sec: 56.01

========================================

Average tokens/sec: 119.35
Memory used: 0.00 GB
```

Eval
```
python3 torchchat.py eval stories15M --tasks wikitext --limit 10

NumExpr defaulting to 10 threads.
PyTorch version 2.5.0.dev20240629 available.
Using device=mps
Loading model...
Time to load model: 0.38 seconds
-----------------------------------------------------------
Using device 'mps'
[Task: wikitext] metric word_perplexity is defined, but aggregation is not. using default aggregation=weighted_perplexity
[Task: wikitext] metric word_perplexity is defined, but higher_is_better is not. using default higher_is_better=False
[Task: wikitext] metric byte_perplexity is defined, but aggregation is not. using default aggregation=weighted_perplexity
[Task: wikitext] metric byte_perplexity is defined, but higher_is_better is not. using default higher_is_better=False
[Task: wikitext] metric bits_per_byte is defined, but aggregation is not. using default aggregation=bits_per_byte
[Task: wikitext] metric bits_per_byte is defined, but higher_is_better is not. using default higher_is_better=False
Repo card metadata block was not found. Setting CardData to empty.
Repo card metadata block was not found. Setting CardData to empty.
Building contexts for wikitext on rank 0...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:00<00:00, 541.59it/s]
Running loglikelihood_rolling requests
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:04<00:00,  2.25it/s]
Time to run eval: 22.57s.
Time in model.forward: 1.01s, over 33 model evaluations
forward run time stats - Median: 0.02s Min: 0.01s Max: 0.27s
For model /Users/puri/.torchchat/model-cache/stories15M/stories15M.pt
wikitext:
 word_perplexity,none: 47350.8811
 byte_perplexity,none: 7.7811
 bits_per_byte,none: 2.9600
 alias: wikitext
```