### PR TITLE
Build runner with PRE-CXX11 abi

### DIFF
--- a/scripts/build_native.sh
+++ b/scripts/build_native.sh
@@ -74,7 +74,7 @@ fi
 popd
 
 # CMake commands
-cmake -S . -B ./cmake-out -DCMAKE_PREFIX_PATH=`python3 -c 'import torch;print(torch.utils.cmake_prefix_path)'` -G Ninja
+cmake -S . -B ./cmake-out -DCMAKE_PREFIX_PATH=`python3 -c 'import torch;print(torch.utils.cmake_prefix_path)'` -DCMAKE_CXX_FLAGS="-D_GLIBCXX_USE_CXX11_ABI=0" -G Ninja
 cmake --build ./cmake-out --target "${TARGET}"_run
 
 printf "Build finished. Please run: \n./cmake-out/${TARGET}_run model.<pte|so> -z tokenizer.model -l <llama version (2 or 3)> -i <prompt>\n"


### PR DESCRIPTION
PyTorch needs it, but if one builds re2 without it and aoti_run with it, it will crash while parsing llama3 tokens

Test plan: `cmake-out/aoti_run exportedModels/llama3.so -z `python3 torchchat.py where llama3`/tokenizer.model -l 3 -i "Once upon a time" -d cuda` works on Linux