### PR TITLE
Explicitly set the D_GLIBCXX_USE_CXX11_ABI when building runners

### DIFF
--- a/scripts/build_native.sh
+++ b/scripts/build_native.sh
@@ -75,7 +75,7 @@ popd
 
 # CMake commands
 if [[ "$TARGET" == "et" ]]; then
-    cmake -S . -B ./cmake-out -DCMAKE_PREFIX_PATH=`python3 -c 'import torch;print(torch.utils.cmake_prefix_path)'` -G Ninja
+    cmake -S . -B ./cmake-out -DCMAKE_PREFIX_PATH=`python3 -c 'import torch;print(torch.utils.cmake_prefix_path)'` -DCMAKE_CXX_FLAGS="-D_GLIBCXX_USE_CXX11_ABI=1" -G Ninja
 else
     cmake -S . -B ./cmake-out -DCMAKE_PREFIX_PATH=`python3 -c 'import torch;print(torch.utils.cmake_prefix_path)'` -DCMAKE_CXX_FLAGS="-D_GLIBCXX_USE_CXX11_ABI=0" -G Ninja
 fi

--- a/scripts/build_native.sh
+++ b/scripts/build_native.sh
@@ -74,7 +74,11 @@ fi
 popd
 
 # CMake commands
-cmake -S . -B ./cmake-out -DCMAKE_PREFIX_PATH=`python3 -c 'import torch;print(torch.utils.cmake_prefix_path)'` -DCMAKE_CXX_FLAGS="-D_GLIBCXX_USE_CXX11_ABI=0" -G Ninja
+if [[ "$TARGET" == "et" ]]; then
+    cmake -S . -B ./cmake-out -DCMAKE_PREFIX_PATH=`python3 -c 'import torch;print(torch.utils.cmake_prefix_path)'` -G Ninja
+else
+    cmake -S . -B ./cmake-out -DCMAKE_PREFIX_PATH=`python3 -c 'import torch;print(torch.utils.cmake_prefix_path)'` -DCMAKE_CXX_FLAGS="-D_GLIBCXX_USE_CXX11_ABI=0" -G Ninja
+fi
 cmake --build ./cmake-out --target "${TARGET}"_run
 
 printf "Build finished. Please run: \n./cmake-out/${TARGET}_run model.<pte|so> -z tokenizer.model -l <llama version (2 or 3)> -i <prompt>\n"


### PR DESCRIPTION
Specific to Linux x86, ET runner segfaults on main, but succeeded prior to the PR https://github.com/pytorch/torchchat/pull/933.
- That specific PR fixes CUDA AOTI for llama 3

This diff expands the D_GLIBCXX_USE_CXX11_ABI to be explicit for both et and aoti. This allows for both the aoti build and et build to succeed.

---
Tested on Linux x86
```
./install_requirements.sh

scripts/build_native.sh aoti
python3 torchchat.py export llama3.1 --output-dso-path exportedModels/llama3-1.so
cmake-out/aoti_run exportedModels/llama3-1.so -z `python3 torchchat.py where llama3.1`/tokenizer.model -l 3 -i "Once upon a time" -d CUDA

export TORCHCHAT_ROOT=${PWD}
./scripts/install_et.sh
 python3 torchchat.py export llama3.1 --quantize config/data/mobile.json --output-pte-path llama3-1.pte
 scripts/build_native.sh et

cmake-out/et_run llama3-1.pte -z `python3 torchchat.py where llama3.1`/tokenizer.model -l 3 -i "Once upon a time"
```

Tested on MAC that runners still work 
```
 ./install_requirements.sh

 python3 torchchat.py export llama3.1 --output-dso-path exportedModels/llama3-1.so\n
 scripts/build_native.sh aoti\n
 cmake-out/aoti_run exportedModels/llama3-1.so -z `python3 torchchat.py where llama3.1`/tokenizer.model -l 3 -i "Once upon a time"\n

 export TORCHCHAT_ROOT=${PWD}\n
 ./scripts/install_et.sh\n
 python3 torchchat.py export llama3.1 --quantize config/data/mobile.json --output-pte-path llama3-1.pte\n
 scripts/build_native.sh et\n

 cmake-out/et_run llama3-1.pte -z `python3 torchchat.py where llama3.1`/tokenizer.model -l 3 -i "Once upon a time"\n
 cmake-out/aoti_run exportedModels/llama3-1.so -z `python3 torchchat.py where llama3.1`/tokenizer.model -l 3 -i "Once upon a time"\n
```