### PR TITLE
Fix CI hang while running `test-readme-mps-macos`

### DIFF
--- a/.github/workflows/run-readme-pr-mps.yml
+++ b/.github/workflows/run-readme-pr-mps.yml
@@ -11,7 +11,7 @@ jobs:
     with:
       runner: macos-m1-14
       script: |
-          conda create -y -n test-readme-mps-macos python=3.10.11
+          conda create -y -n test-readme-mps-macos python=3.10.11 llvm-openmp
           conda activate test-readme-mps-macos
           set -x
           # NS: Remove previous installation  of torch first


### PR DESCRIPTION
By installing `llvm-openmp`, which prevents hang on the process shutdown due to the double loading of openmp library, that looks like a timeout in CI, see https://github.com/pytorch/torchchat/actions/runs/10101744183/job/27945942279 for example.
OpenMP from Anaconda interoperates nicely with the one bundled into the PyTorch.