### PR TITLE
[Draft Test] CI: Set the MPS watermark to avoid running out of MPS memory

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -449,6 +449,7 @@ jobs:
           fi
       - name: Install requirements
         run: |
+          PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0
           echo "Intalling pip3 packages"
           ./install_requirements.sh
 
@@ -588,6 +589,7 @@ jobs:
           fi
       - name: Install requirements
         run: |
+          PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0
           echo "Installing pip3 packages"
           ./install_requirements.sh
           pip3 list
@@ -809,6 +811,7 @@ jobs:
           fi
       - name: Install requirements
         run: |
+          PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0
           ./install_requirements.sh
           pip3 list
           python3 -c 'import torch;print(f"torch: {torch.__version__, torch.version.git_version}")'
@@ -887,6 +890,7 @@ jobs:
           fi
       - name: Install torchchat
         run: |
+          PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0
           echo "Intalling pip3 packages"
           ./install_requirements.sh
           pip3 list
@@ -975,6 +979,7 @@ jobs:
           echo "$(uname -a)"
       - name: Install dependencies
         run: |
+          PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0
           ./install_requirements.sh
           pip3 list
           python3 -c 'import torch;print(f"torch: {torch.__version__, torch.version.git_version}")'


### PR DESCRIPTION
Some CI tests using MPS were failing due to memory usage. This explicitly sets the RATIO as suggested
```
Please file an issue with the following so that we can make `weights_only=True` compatible with your use case: WeightsUnpickler error: MPS backend out of memory (MPS allocated: 1.02 GB, other allocations: 0 bytes, max allowed: 15.87 GB). Tried to allocate 256 bytes on shared pool. Use PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0 to disable upper limit for memory allocations (may cause system failure).
```

**Example Job:** https://github.com/pytorch/torchchat/actions/runs/10166476129/job/28116731017