### PR TITLE
deps: Add set -x for installation commands

### DIFF
--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -5,6 +5,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+set -eou pipefail
+
 # Install required python dependencies for developing
 # Dependencies are defined in .pyproject.toml
 if [[ -z $PYTHON_EXECUTABLE ]];
@@ -37,7 +39,10 @@ fi
 # newer version of torch nightly installed later in this script.
 #
 
-$PIP_EXECUTABLE install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/nightly/cu121
+(
+  set -x
+  $PIP_EXECUTABLE install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/nightly/cu121
+)
 
 # Since torchchat often uses main-branch features of pytorch, only the nightly
 # pip versions will have the required features. The NIGHTLY_VERSION value should
@@ -49,7 +54,10 @@ $PIP_EXECUTABLE install -r requirements.txt --extra-index-url https://download.p
 NIGHTLY_VERSION=dev20240710
 
 # Uninstall triton, as nightly will depend on pytorch-triton, which is one and the same
-$PIP_EXECUTABLE uninstall -y triton
+(
+  set -x
+  $PIP_EXECUTABLE uninstall -y triton
+)
 
 # The pip repository that hosts nightly torch packages. cpu by default.
 # If cuda is available, based on presence of nvidia-smi, install the pytorch nightly
@@ -68,12 +76,21 @@ REQUIREMENTS_TO_INSTALL=(
 
 # Install the requirements. `--extra-index-url` tells pip to look for package
 # versions on the provided URL if they aren't available on the default URL.
-$PIP_EXECUTABLE install --extra-index-url "${TORCH_NIGHTLY_URL}" \
+(
+  set -x
+  $PIP_EXECUTABLE install --extra-index-url "${TORCH_NIGHTLY_URL}" \
     "${REQUIREMENTS_TO_INSTALL[@]}"
+)
 
 # For torchao need to install from github since nightly build doesn't have macos build.
 # TODO: Remove this and install nightly build, once it supports macos
-$PIP_EXECUTABLE install git+https://github.com/pytorch/ao.git@d36de1b144b73bf753bd082109c2b5d0141abd5b
+(
+  set -x
+  $PIP_EXECUTABLE install git+https://github.com/pytorch/ao.git@d36de1b144b73bf753bd082109c2b5d0141abd5b
+)
 if [[ -x "$(command -v nvidia-smi)" ]]; then
-  $PYTHON_EXECUTABLE scripts/patch_triton.py
+  (
+    set -x
+    $PYTHON_EXECUTABLE scripts/patch_triton.py
+  )
 fi

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -9,14 +9,10 @@ set -eou pipefail
 
 # Install required python dependencies for developing
 # Dependencies are defined in .pyproject.toml
-if [[ -z $PYTHON_EXECUTABLE ]];
+PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE:-python}
+if [[ -z $CONDA_DEFAULT_ENV ]] || [[ $CONDA_DEFAULT_ENV == "base" ]] || [[ ! -x "$(command -v python)" ]];
 then
-  if [[ -z $CONDA_DEFAULT_ENV ]] || [[ $CONDA_DEFAULT_ENV == "base" ]] || [[ ! -x "$(command -v python)" ]];
-  then
-    PYTHON_EXECUTABLE=python3
-  else
-    PYTHON_EXECUTABLE=python
-  fi
+  PYTHON_EXECUTABLE=python3
 fi
 
 # Check python version. Expect 3.10.x or 3.11.x

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -10,7 +10,7 @@ set -eou pipefail
 # Install required python dependencies for developing
 # Dependencies are defined in .pyproject.toml
 PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE:-python}
-if [[ -z $CONDA_DEFAULT_ENV ]] || [[ $CONDA_DEFAULT_ENV == "base" ]] || [[ ! -x "$(command -v python)" ]];
+if [[ -z ${CONDA_DEFAULT_ENV:-} ]] || [[ ${CONDA_DEFAULT_ENV:-} == "base" ]] || [[ ! -x "$(command -v python)" ]];
 then
   PYTHON_EXECUTABLE=python3
 fi


### PR DESCRIPTION
Adds set -x for all installation commands in install_requirements.sh so that users can see what's actually being installed and can help debug when they run into any issues.

NOTE: This doesn't turn it on for all of the script (since that'd be overbearing) but rather turns it on specifically when installing things.

This also adds "set -eou pipefail" to the top of the script which is a recommended paradigm for all bash scripts since it adds things like error on exit, error on undefined variable, and propagation of errors on pipe failure.

https://explainshell.com/explain?cmd=set+-euo+pipefail