### PR TITLE
Fix GeneratorArgs to avoid unsafely accessing prompt and num_samples

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -110,11 +110,11 @@ class GeneratorArgs:
         )
 
         return cls(
-            prompt=args.prompt,
+            prompt=getattr(args, "prompt", ""),
             encoded_prompt=None,
             chat_mode=args.chat,
             gui_mode=args.gui,
-            num_samples=args.num_samples,
+            num_samples=getattr(args, "num_samples", 1),
             max_new_tokens=args.max_new_tokens,
             top_k=args.top_k,
             temperature=args.temperature,


### PR DESCRIPTION
Prompt and num_samples were restricted from suppressed arg (always accepted as CLI arg even when not used by subcommand) to being restricted to `generate` in https://github.com/pytorch/torchchat/pull/987.

But this PR missed a call site. This updates the callsite that was missed to not access the field without checking for existence

Tested that both these commands no longer crash with accessing unavailable fields:
- python3 torchchat.py generate llama3.1
- python3 torchchat.py server llama3.1

Fixes: https://github.com/pytorch/torchchat/issues/1003