### PR TITLE
Add OPENAI_API_VERSION constant to routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ is plaintext and will not be formatted to the OpenAI API specification. If `stre
 [skip default]: begin
 
 ```
-curl http://127.0.0.1:5000/chat \
+curl http://127.0.0.1:5000/v1/chat \
   -H "Content-Type: application/json" \
   -d '{
     "model": "llama3.1",

--- a/server.py
+++ b/server.py
@@ -16,6 +16,8 @@ from build.builder import BuilderArgs, TokenizerArgs
 from flask import Flask, request, Response
 from generate import GeneratorArgs
 
+OPENAI_API_VERSION = "v1"
+
 
 def create_app(args):
     """
@@ -33,7 +35,7 @@ def create_app(args):
             return [_del_none(v) for v in d if v]
         return d
 
-    @app.route("/chat", methods=["POST"])
+    @app.route(f"/{OPENAI_API_VERSION}/chat", methods=["POST"])
     def chat_endpoint():
         """
         Endpoint for the Chat API. This endpoint is used to generate a response to a user prompt.
@@ -75,11 +77,11 @@ def create_app(args):
 
             return json.dumps(_del_none(asdict(response)))
 
-    @app.route("/models", methods=["GET"])
+    @app.route(f"/{OPENAI_API_VERSION}/models", methods=["GET"])
     def models_endpoint():
         return json.dumps(asdict(get_model_info_list(args)))
 
-    @app.route("/models/<model_id>", methods=["GET"])
+    @app.route(f"/{OPENAI_API_VERSION}/models/<model_id>", methods=["GET"])
     def models_retrieve_endpoint(model_id):
         if response := retrieve_model_info(args, model_id):
             return json.dumps(asdict(response))


### PR DESCRIPTION
Server routes were missing the "v1" portion. This is expected by OpenWebUI and other tools. See https://platform.openai.com/docs/api-reference/

Testing:

Run server
```
python3 torchchat.py server stories15M
```

In another terminal:
```
curl http://127.0.0.1:5000/v1/models
{"data": [{"id": "stories15M", "created": 1722531822, "owner": "puri", "object": "model"}], "object": "list"}%    
```

```curl http://127.0.0.1:5000/v1/chat \
  -H "Content-Type: application/json" \
  -d '{
    "model": "stories15M",
    "stream": "true",
    "messages": [
      {
        "role": "system",
        "content": "You are a helpful assistant."
      },
      {
        "role": "user",
        "content": "Hello!"
      }
    ]
  }'


{"id": "621d4fc8-855e-4660-87af-3f2cf2a75a90", "choices": [{"delta": {"role": "assistant", "content": " She"}}], "created": 1722978694, "model": "stories15m", "system_fingerprint": "mpsdtype", "object": "chat.completion.chunk"}{"id": "621d4fc8-855e-4660-87af-3f2cf2a75a90", "choices": [{"delta": {"role": "assistant", "content": " was"}, "index": 1}], "created": 1722978695, "model": "stories15m", "system_fingerprint": "mpsdtype", "object": "chat.completion.chunk"}{"id": "621d4fc8-855e-4660-87af-3f2cf2a75a90", "choices": [{"delta": {"role": "assistant", "content": " a"}, "index": 2}], "created": 1722978695, "model": "stories15m", "system_fingerprint": "mpsdtype", "object": "chat.completion.chunk"}{"id": "621d4fc8-855e-4660-87af-3f2cf2a75a90", "choices": [{"delta": {"role": "assistant", "content": " little"}, "index": 3}],

...

# Continues outputting Completion Chunk Response objects

```
