### PR TITLE
Openai api completion params [seed, temperature, max_tokens, system_fingerprint]

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ streamlit run torchchat.py -- browser llama3.1
 <details>
 <summary>This mode gives a REST API that matches the OpenAI API spec for interacting with a model</summary>
 
+The server follows the [OpenAI API specification](https://platform.openai.com/docs/api-reference/chat) for chat completions.
+Since this feature is under active development, it's possible not every parameter is consumed. See api/api.py for details on
+which request parameters are implemented. If you encounter any issues, please comment on the [tracking Github issue](https://github.com/pytorch/torchchat/issues/973).
+
 To test out the REST API, **you'll need 2 terminals**: one to host the server, and one to send the request.
 
 In one terminal, start the server
@@ -213,8 +217,7 @@ python3 torchchat.py server llama3.1
 
 In another terminal, query the server using `curl`. Depending on the model configuration, this query might take a few minutes to respond.
 
-Setting `stream` to "true" in the request emits a response in chunks. Currently, this response
-is plaintext and will not be formatted to the OpenAI API specification. If `stream` is unset or not "true", then the client will await the full response from the server.
+Setting `stream` to "true" in the request emits a response in chunks. If `stream` is unset or not "true", then the client will await the full response from the server.
 
 
 **Example Input + Output**
@@ -227,6 +230,7 @@ curl http://127.0.0.1:5000/v1/chat \
   -d '{
     "model": "llama3.1",
     "stream": "true",
+    "max_tokens": 200,
     "messages": [
       {
         "role": "system",

--- a/generate.py
+++ b/generate.py
@@ -71,7 +71,7 @@ class GeneratorArgs:
     num_samples: int = 1
     max_new_tokens: int = 200
     top_k: int = 200
-    temperature: int = 0  # deterministic argmax
+    temperature: float = 0.0  # deterministic argmax if 0.0
     compile: bool = False
     compile_prefill: bool = False
     speculate_k: int = 5
@@ -105,9 +105,7 @@ class GeneratorArgs:
     def from_args(cls, args):
         dso_path = getattr(args, "dso_path", None)
         pte_path = getattr(args, "pte_path", None)
-        sequential_prefill = (
-            args.sequential_prefill or bool(dso_path) or bool(pte_path)
-        )
+        sequential_prefill = args.sequential_prefill or bool(dso_path) or bool(pte_path)
 
         return cls(
             prompt=getattr(args, "prompt", ""),

--- a/server.py
+++ b/server.py
@@ -9,6 +9,8 @@ import json
 from dataclasses import asdict
 from typing import Dict, List, Union
 
+import torch
+
 from api.api import CompletionRequest, OpenAiApiGenerator
 from api.models import get_model_info_list, retrieve_model_info
 
@@ -50,6 +52,8 @@ def create_app(args):
         """
 
         print(" === Completion Request ===")
+        if seed := request.args.get("seed"):
+            torch.manual_seed(int(seed))
 
         # Parse the request in to a CompletionRequest object
         data = request.get_json()


### PR DESCRIPTION
**Implement [seed, temperature, max_tokens, system_fingerprint(partial)]** 
Improve determinism of generated responses. 
- seed: simply set torch.manual_seed() each time the seed is provided
- max_tokens: default to 16 as per API spec.
- temperature: default to 1.0 as per API spec.  
- system_fingerprint: for now, the backend and torch.dtype of the model weights. In the future, we should add model version information to this. 


Testing: With the same seeds, the generated response is the same. 

https://github.com/user-attachments/assets/7b186f86-5855-4b9e-92c3-cc617727c752




Tested with the following cURL:
```
curl http://127.0.0.1:5000/v1/chat \
  -H "Content-Type: application/json" \
  -d '{
    "model": "stories15M",
    "stream": "true",
    "max_tokens": "123",
    "temperature": "0.2",
    "seed": "813",
    "messages": [
      {
        "role": "system",
        "content": "You are a helpful assistant."
      },
      {
        "role": "user",
        "content": "Story about a dog."
      }
    ]
  }'
```

