### PR TITLE
Add ability to select models and edit system/assistant prompts

### DIFF
--- a/browser/browser.py
+++ b/browser/browser.py
@@ -1,36 +1,82 @@
 import time
+
 import streamlit as st
 from openai import OpenAI
 
 st.title("torchchat")
 
-start_state = [
-    {
-        "role": "system",
-        "content": "You're an assistant. Answer questions directly, be brief, and have fun.",
-    },
-    {"role": "assistant", "content": "How can I help you?"},
-]
+client = OpenAI(
+    base_url="http://127.0.0.1:5000/v1",
+    api_key="813",  # The OpenAI API requires an API key, but since we don't consume it, this can be any non-empty string.
+)
+
 
 with st.sidebar:
     response_max_tokens = st.slider(
         "Max Response Tokens", min_value=10, max_value=1000, value=250, step=10
     )
+    st.divider()
+
+    # Build model list and allow user to change the model running on the server.
+    try:
+        models = client.models.list().data
+        model_keys = [model.id for model in models]
+    except:
+        models = []
+        model_keys = []
+    selected_model = st.selectbox(
+        label="Model",
+        options=model_keys,
+    )
+    is_instruct_model = "instruct" in selected_model.lower()
+
+    st.divider()
+
+    # Change system prompt and default chat message.
+    system_prompt = st.text_area(
+        label="System Prompt",
+        value=(
+            "You're an assistant. Answer questions directly, be brief, and have fun."
+            if is_instruct_model
+            else f'Selected model "{selected_model}" doesn\'t support chat.'
+        ),
+        disabled=not is_instruct_model,
+    )
+    assistant_prompt = st.text_area(
+        label="Assistant Prompt",
+        value=(
+            "How can I help you?"
+            if is_instruct_model
+            else f'Selected model "{selected_model}" doesn\'t support chat.'
+        ),
+        disabled=not is_instruct_model,
+    )
+
+    st.divider()
+
+    # Manage chat histoory and prompts.
+    start_state = (
+        [
+            {
+                "role": "system",
+                "content": system_prompt,
+            },
+            {"role": "assistant", "content": assistant_prompt},
+        ]
+        if is_instruct_model
+        else []
+    )
     if st.button("Reset Chat", type="primary"):
         st.session_state["messages"] = start_state
 
-if "messages" not in st.session_state:
-    st.session_state["messages"] = start_state
+
+st.session_state["messages"] = start_state
 
 
 for msg in st.session_state.messages:
     st.chat_message(msg["role"]).write(msg["content"])
 
 if prompt := st.chat_input():
-    client = OpenAI(
-        base_url="http://127.0.0.1:5000/v1",
-        api_key="813",  # The OpenAI API requires an API key, but since we don't consume it, this can be any non-empty string.
-    )
 
     st.session_state.messages.append({"role": "user", "content": prompt})
     st.chat_message("user").write(prompt)
@@ -56,7 +102,7 @@ if prompt := st.chat_input():
         response = st.write_stream(
             get_streamed_completion(
                 client.chat.completions.create(
-                    model="llama3",
+                    model=selected_model,
                     messages=st.session_state.messages,
                     max_tokens=response_max_tokens,
                     stream=True,


### PR DESCRIPTION
**Goal: ** Users should be able to select the model from the chat interface and receive a response from that model. 

**Currently:** we just send the request and take the response from whatever model the "server" process has loaded. To load a different model, the user would have to stop the server and re-start it with different CLI args. 

**Solution:** This is a bit tricky. OpenAI can just route the request to a system that already has the model loaded. If we wanted to replicate this functionality, the user's system would quickly run out of memory to have even two instances of low-parameter models loaded. To get around this, we'll just assume that the system will *only ever have a single model loaded*. 

Flow:
* User will have a dropdown of model IDs (retrieved from the /models endpoint). 
* Upon selecting a different model, the user should press a confirmation button to initiate the model unload/load. If we didn't do this, then someone messing around with the UI might accidentally trigger a multi-second, intensive operation which isn't intended. 
* Pressing this button will submit a query to the server to swap out its models.
* First, we will validate that the model is still on the server. It should be since we just queried /models, and this is re-queried every time a selection in the dropdown is made. If not, the server should return an appropriate error response. 
* While no model is loaded and the query has been submitted, input elements should be disabled until a response is received
* The default prompts (i.e. assistant prompt, system prompt) should be enabled or disabled based on whether or not the model supports chat. 


****Warning**** This PR is still in draft status and does not yet include server side changes.