### PR TITLE
Fix assertion failure during chat session.

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -745,9 +745,7 @@ class Generator:
                             {"role": "user", "content": prompt}
                         )
                         encoded.extend(
-                            self.chat_formatter.encode_header(
-                                {"role": "assistant", "content": ""}
-                            )
+                            self.chat_formatter.encode_header("assistant")
                         )
                     encoded = torch.tensor(
                         encoded, dtype=torch.int, device=self.builder_args.device


### PR DESCRIPTION
This fixes the following assert that is easy to repro in any chat session:

```
Traceback (most recent call last):
    File "/home/ubuntu/cali/torchchat/torchchat.py", line 69, in <module>
        generate_main(args)
    File "/home/ubuntu/cali/torchchat/generate.py", line 896, in main
        for _ in gen.chat(generator_args):
    File "/home/ubuntu/cali/torchchat/generate.py", line 748, in chat
        self.chat_formatter.encode_header(
    File "/home/ubuntu/cali/torchchat/generate.py", line 53, in encode_header
        tokens.extend(self.tokenizer.encode(role, bos=False, eos=False))
    File "/home/ubuntu/cali/torchchat/tokenizer/tiktoken.py", line 133, in encode
        assert type(s) is str
```

I believe this regressed with https://github.com/pytorch/torchchat/pull/1035.