### PR TITLE
[Hackability Refactor] Move build/util into torchchat/utils

### DIFF
--- a/build/gguf_loader.py
+++ b/build/gguf_loader.py
@@ -19,7 +19,7 @@ from torchchat.model import Model, ModelArgs, TransformerArgs
 from gguf import GGUFValueType
 from quantization.quantize import group_dequantize_tensor_from_qparams, pack_scales_and_zeros
 
-from build.utils import find_multiple, get_precision
+from torchchat.utils.build_utils import find_multiple, get_precision
 
 
 logger: logging.Logger = logging.getLogger(__name__)

--- a/build/model_dist.py
+++ b/build/model_dist.py
@@ -15,7 +15,7 @@ from torch.distributed._tensor import DTensor, Replicate
 from torch.distributed.device_mesh import _mesh_resources, DeviceMesh
 from torch.distributed.tensor.parallel import parallelize_module, ColwiseParallel, RowwiseParallel
 
-from build.utils import find_multiple
+from torchchat.utils.build_utils import find_multiple
 
 from torchchat.model import TransformerArgs, KVCache, apply_rotary_emb, precompute_freqs_cis
 

--- a/eval.py
+++ b/eval.py
@@ -17,7 +17,7 @@ from torchchat.cli.builder import (
 )
 
 from torchchat.model import Model
-from build.utils import set_precision
+from torchchat.utils.build_utils import set_precision
 from torchchat.cli.cli import add_arguments_for_verb, arg_init
 from torchchat.utils.measure_time import measure_time
 

--- a/export.py
+++ b/export.py
@@ -20,7 +20,7 @@ from torchchat.cli.builder import (
     TokenizerArgs,
 )
 
-from build.utils import set_backend, set_precision
+from torchchat.utils.build_utils import set_backend, set_precision
 from torchchat.cli.cli import add_arguments_for_verb, arg_init, check_args
 
 from torch.export import Dim
@@ -94,7 +94,7 @@ try:
     import executorch.exir as exir
 
     from torchchat.model import apply_rotary_emb, Attention
-    from build.utils import get_precision
+    from torchchat.utils.build_utils import get_precision
 
     from executorch.backends.xnnpack.partition.xnnpack_partitioner import (
         XnnpackDynamicallyQuantizedPartitioner,

--- a/generate.py
+++ b/generate.py
@@ -26,7 +26,7 @@ from torchchat.cli.builder import (
     TokenizerArgs,
 )
 from torchchat.model import Model
-from build.utils import device_sync, set_precision
+from torchchat.utils.build_utils import device_sync, set_precision
 from torchchat.cli.cli import add_arguments_for_verb, arg_init, check_args
 from torchchat.utils.device_info import get_device_info
 

--- a/quantization/quantize.py
+++ b/quantization/quantize.py
@@ -31,7 +31,7 @@ from typing import Dict, Optional
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from build.utils import (
+from torchchat.utils.build_utils import (
     find_multiple,
     get_device_str,
     get_precision,

--- a/torchchat/cli/builder.py
+++ b/torchchat/cli/builder.py
@@ -28,7 +28,7 @@ from torch.distributed.device_mesh import DeviceMesh
 from torchchat.utils.measure_time import measure_time
 
 from torchchat.model import Model
-from build.utils import device_sync, is_cpu_device, is_cuda_or_cpu_device, name_to_dtype
+from torchchat.utils.build_utils import device_sync, is_cpu_device, is_cuda_or_cpu_device, name_to_dtype
 
 
 @dataclass

--- a/torchchat/cli/cli.py
+++ b/torchchat/cli/cli.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import torch
 
-from build.utils import allowable_dtype_names, allowable_params_table, get_device_str
+from torchchat.utils.build_utils import allowable_dtype_names, allowable_params_table, get_device_str
 from torchchat.cli.download import download_and_convert, is_model_downloaded
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")

--- a/torchchat/model.py
+++ b/torchchat/model.py
@@ -16,9 +16,9 @@ import torch.nn as nn
 from torch import Tensor
 from torch.nn import functional as F
 
-from build.utils import find_multiple, get_precision
+from torchchat.utils.build_utils import find_multiple, get_precision
 
-config_path = Path(f"{str(Path(__file__).parent.parent)}/torchchat/model_params")
+config_path = Path(f"{str(Path(__file__).parent)}/model_params")
 
 
 @dataclass

--- a/torchchat/usages/openai_api.py
+++ b/torchchat/usages/openai_api.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import torch
 
-from build.utils import device_sync
+from torchchat.utils.build_utils import device_sync
 from download import is_model_downloaded, load_model_configs
 from generate import Generator, GeneratorArgs
 

--- a/torchchat/utils/build_utils.py
+++ b/torchchat/utils/build_utils.py
@@ -171,7 +171,7 @@ name_to_dtype_dict = {
 
 
 def allowable_params_table() -> List[str]:
-    config_path = Path(f"{str(Path(__file__).parent.parent)}/torchchat/model_params")
+    config_path = Path(f"{str(Path(__file__).parent.parent)}/model_params")
     known_model_params = [
         config.replace(".json", "") for config in os.listdir(config_path)
     ]


### PR DESCRIPTION
Specifically the file is renamed to build_utils