### PR TITLE
[easy] Undo Extra Redirection for adb Paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ The following assumes you've completed the steps for [Setting up ExecuTorch](#se
 
    - [executorch-llama-tiktoken-rc3-0719.aar](https://ossci-android.s3.amazonaws.com/executorch/main/executorch-llama-tiktoken-rc3-0719.aar) (SHASUM: c3e5d2a97708f033c2b1839a89f12f737e3bbbef)
 
-2. Rename the downloaded AAR file to `executorch.aar` and move the file to `torchchat/edge/android/torchchat/app/libs/`. You may need to create directory `torchchat/edge/android/torchchat/app/libs/` if it does not exist.
+2. Rename the downloaded AAR file to `executorch.aar` and move the file to `android/torchchat/app/libs/`. You may need to create directory `android/torchchat/app/libs/` if it does not exist.
 
 3. Push the model and tokenizer file to your device. You can find the model file called `llama3.1.pte` in the current `torchchat` directory and the tokenizer file at `$(python3 torchchat.py where llama3.1)/tokenizer.model` path.
     ```

--- a/scripts/android_example.sh
+++ b/scripts/android_example.sh
@@ -158,7 +158,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   run_android_instrumented_test
 fi
 
-adb install -t torchchat/edge/android/torchchat/app/build/outputs/apk/debug/app-debug.apk
+adb install -t android/torchchat/app/build/outputs/apk/debug/app-debug.apk
 
 if [ -z "${CI_ENV:-}" ]; then
   read -p "Press enter to exit emulator and finish"


### PR DESCRIPTION
Introduced in https://github.com/pytorch/torchchat/pull/1046, the `torchchat/edge` path header reflects the structure in the repo, but is unnecessary when abd'ing the android local path.

This PR just undo's that extra indirection