### PR TITLE
[Consolidate] Move parallelization code into a .distribute() method

### DIFF
--- a/dist_run.py
+++ b/dist_run.py
@@ -19,8 +19,8 @@ from distributed.safetensor_utils import (
 )
 from distributed.utils import Color as color
 from torch.distributed.pipelining import PipelineStage, ScheduleGPipe
-from torchchat.model import ModelArgs, TransformerArgs
-from torchchat.model_dist import TransformerStage
+from torchchat.model import ModelArgs
+from torchchat.model_dist import Transformer
 from torchchat.utils.build_utils import get_precision
 
 MODEL_NAME = "Transformer-2-7b-chat-hf"
@@ -84,8 +84,12 @@ def main():
     nstages = pp_mesh.size()
     device = torch.device(f"cuda:{rank}")
 
+    # Fill in PP configs
+    config.stage_idx = pp_rank
+    config.n_stages = nstages
+
     with device:
-        model = TransformerStage(config, pp_rank, nstages)
+        model = Transformer(config)
 
     model.setup_caches(1, 4096)
     # TODO: refine this .to once we start using fp8 for KV cache

--- a/dist_run.py
+++ b/dist_run.py
@@ -85,11 +85,14 @@ def main():
     device = torch.device(f"cuda:{rank}")
 
     with device:
-        with tp_mesh:
-            model = TransformerStage(config, pp_rank, nstages)
-            model.setup_caches(1, 4096)
-            # TODO: refine this .to once we start using fp8 for KV cache
-            model = model.to(model_dtype)
+        model = TransformerStage(config, pp_rank, nstages)
+
+    model.setup_caches(1, 4096)
+    # TODO: refine this .to once we start using fp8 for KV cache
+    model = model.to(model_dtype)
+
+    # Distribute model on TP mesh
+    model.distribute(tp_mesh)
     logger.info(f"Model: {model}")
 
     mbs = 2  # number of micro-batches

--- a/torchchat/model.py
+++ b/torchchat/model.py
@@ -40,6 +40,9 @@ class TransformerArgs:
     use_tiktoken: bool = False
     max_seq_length: int = 8192
     use_scaled_rope: bool = False
+    # For pipeline parallel
+    n_stages: int = 1
+    stage_idx: int = 0
 
     def __post_init__(self):
         if self.n_local_heads == -1:

--- a/torchchat/model_dist.py
+++ b/torchchat/model_dist.py
@@ -10,8 +10,8 @@ import torch
 import torch.nn as nn
 
 from torch import Tensor
-from torch.distributed._tensor import DTensor, Replicate
-from torch.distributed.device_mesh import _mesh_resources, DeviceMesh
+from torch.distributed._tensor import Replicate
+from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor.parallel import (
     ColwiseParallel,
     parallelize_module,
@@ -30,17 +30,10 @@ from torchchat.utils.build_utils import find_multiple
 
 config_path = Path(f"{str(Path(__file__).parent)}/known_model_params")
 
-from distributed.logging_utils import setup_logging
-
-logger = setup_logging(__name__)
 
 # Use DTensor as output, by default
 Colwise = ColwiseParallel(use_local_output=False)
 Rowwise = RowwiseParallel(use_local_output=False)
-
-# Device mesh context
-device_mesh = None
-
 
 class TransformerStage(nn.Module):
     def __init__(self, config: TransformerArgs, stage_idx: int, n_stages: int) -> None:
@@ -50,18 +43,8 @@ class TransformerStage(nn.Module):
         self.n_stages = n_stages
         self.layers_per_stage = config.n_layers // n_stages
 
-        # Get device mesh
-        global device_mesh
-        if device_mesh is None:
-            device_mesh = _mesh_resources.get_current_mesh()
-
         if stage_idx == 0:
-            tok_embeddings = nn.Embedding(config.vocab_size, config.dim)
-            self.tok_embeddings = parallelize_module(
-                tok_embeddings,
-                device_mesh,
-                RowwiseParallel(input_layouts=Replicate()),
-            )
+            self.tok_embeddings = nn.Embedding(config.vocab_size, config.dim)
 
         # Use ModuleDict so that each layer can be assigned its layer ID in the original model
         self.layers = nn.ModuleDict()
@@ -107,6 +90,21 @@ class TransformerStage(nn.Module):
         )
         self.register_buffer("causal_mask", causal_mask, persistent=True)
 
+    def distribute(self, device_mesh: DeviceMesh):
+        if hasattr(self, "tok_embeddings"):
+            parallelize_module(
+                self.tok_embeddings,
+                device_mesh,
+                RowwiseParallel(input_layouts=Replicate()),
+            )
+        for layer in self.layers.values():
+            layer.distribute(device_mesh)
+        # TODO (kwen2501) : parallelize these
+        """
+        parallelize_module(self.norm, device_mesh, ...)
+        parallelize_module(self.output, device_mesh, ...)
+        """
+
     def forward(self, x: Tensor, input_pos: Optional[Tensor] = None) -> Tensor:
         assert self.freqs_cis is not None, "Caches must be initialized first"
         if input_pos is None:
@@ -115,7 +113,7 @@ class TransformerStage(nn.Module):
         freqs_cis = self.freqs_cis[input_pos]
 
         if self.stage_idx == 0:
-            x: DTensor = self.tok_embeddings(x)
+            x = self.tok_embeddings(x)
             # TODO: sequence parallelize this
 
         for _, layer in self.layers.items():
@@ -159,6 +157,12 @@ class TransformerBlock(nn.Module):
         self.ffn_norm = RMSNorm(config.dim, config.norm_eps)
         self.attention_norm = RMSNorm(config.dim, config.norm_eps)
 
+    def distribute(self, device_mesh: DeviceMesh):
+        self.attention.distribute(device_mesh)
+        self.feed_forward.distribute(device_mesh)
+        self.ffn_norm.distribute(device_mesh)
+        self.attention_norm.distribute(device_mesh)
+
     def forward(
         self, x: Tensor, input_pos: Tensor, freqs_cis: Tensor, mask: Tensor
     ) -> Tensor:
@@ -175,15 +179,10 @@ class Attention(nn.Module):
         # key, query, value projections for all heads, but in a batch
         # total_head_dim = (config.n_heads + 2 * config.n_local_heads) * config.head_dim
         # self.wqkv = nn.Linear(config.dim, total_head_dim, bias=False)
-        wq = nn.Linear(config.dim, config.n_heads * config.head_dim, bias=False)
-        wk = nn.Linear(config.dim, config.n_local_heads * config.head_dim, bias=False)
-        wv = nn.Linear(config.dim, config.n_local_heads * config.head_dim, bias=False)
-        wo = nn.Linear(config.dim, config.dim, bias=False)
-
-        self.wq = parallelize_module(wq, device_mesh, Colwise)
-        self.wk = parallelize_module(wk, device_mesh, Colwise)
-        self.wv = parallelize_module(wv, device_mesh, Colwise)
-        self.wo = parallelize_module(wo, device_mesh, Rowwise)
+        self.wq = nn.Linear(config.dim, config.n_heads * config.head_dim, bias=False)
+        self.wk = nn.Linear(config.dim, config.n_local_heads * config.head_dim, bias=False)
+        self.wv = nn.Linear(config.dim, config.n_local_heads * config.head_dim, bias=False)
+        self.wo = nn.Linear(config.dim, config.dim, bias=False)
 
         self.kv_cache = None
 
@@ -231,6 +230,12 @@ class Attention(nn.Module):
 
         _unfuse_wqkv_state_dict(state_dict, self.dim)
 
+    def distribute(self, device_mesh: DeviceMesh):
+        parallelize_module(self.wq, device_mesh, Colwise)
+        parallelize_module(self.wk, device_mesh, Colwise)
+        parallelize_module(self.wv, device_mesh, Colwise)
+        parallelize_module(self.wo, device_mesh, Rowwise)
+
     def forward(
         self,
         x: Tensor,
@@ -240,9 +245,9 @@ class Attention(nn.Module):
     ) -> Tensor:
         bsz, seqlen, _ = x.shape
 
-        q: DTensor = self.wq(x)
-        k: DTensor = self.wk(x)
-        v: DTensor = self.wv(x)
+        q = self.wq(x)
+        k = self.wk(x)
+        v = self.wv(x)
         # We use `to_local()` to convert DTensor back to regular Tensor
         q, k, v = q.to_local(), k.to_local(), v.to_local()
         # kv_size = self.n_local_heads * self.head_dim
@@ -267,7 +272,7 @@ class Attention(nn.Module):
 
         y = y.transpose(1, 2).contiguous().view(bsz, seqlen, -1)
 
-        y: DTensor = self.wo(y)
+        y = self.wo(y)
         # TODO: sequence parallelize this
         return y.full_tensor()
 
@@ -275,15 +280,17 @@ class Attention(nn.Module):
 class FeedForward(nn.Module):
     def __init__(self, config: TransformerArgs) -> None:
         super().__init__()
-        w1 = nn.Linear(config.dim, config.hidden_dim, bias=False)
-        w2 = nn.Linear(config.hidden_dim, config.dim, bias=False)
-        w3 = nn.Linear(config.dim, config.hidden_dim, bias=False)
-        self.w1 = parallelize_module(w1, device_mesh, Colwise)
-        self.w2 = parallelize_module(w2, device_mesh, Rowwise)
-        self.w3 = parallelize_module(w3, device_mesh, Colwise)
+        self.w1 = nn.Linear(config.dim, config.hidden_dim, bias=False)
+        self.w2 = nn.Linear(config.hidden_dim, config.dim, bias=False)
+        self.w3 = nn.Linear(config.dim, config.hidden_dim, bias=False)
+
+    def distribute(self, device_mesh: DeviceMesh):
+        parallelize_module(self.w1, device_mesh, Colwise)
+        parallelize_module(self.w2, device_mesh, Rowwise)
+        parallelize_module(self.w3, device_mesh, Colwise)
 
     def forward(self, x: Tensor) -> Tensor:
-        y: DTensor = self.w2(F.silu(self.w1(x)) * self.w3(x))
+        y = self.w2(F.silu(self.w1(x)) * self.w3(x))
         # y is a DTensor with Partial placement;
         # we convert its placement to Replicate and convert it back to a regular
         # Tensor. `full_tensor` is the API that does both.
@@ -296,6 +303,13 @@ class RMSNorm(nn.Module):
         super().__init__()
         self.eps = eps
         self.weight = nn.Parameter(torch.ones(dim))
+
+    def distribute(self, device_mesh: DeviceMesh):
+        # TODO (kwen2501): parallelize this
+        """
+        parallelize_module(self.weight, device_mesh, Colwise)
+        """
+        pass
 
     def _norm(self, x):
         return x * torch.rsqrt(torch.mean(x * x, dim=-1, keepdim=True) + self.eps)


### PR DESCRIPTION
The goal is to make the difference between `model.py` and `model_dist.py` as small as possible, and eventually consolidate them.

**[Consolidate TP]**

A first step is to move the parallelization code out from `.__init__()` into a separate `.distribute()` method, which is now an optional call:

```
model = Transformer(config)
model.distribute(tp_mesh)
```

`model.distribute` is a recursive call -- when hitting the child modules, it calls PyTorch's `parallelize_module` API with column-wise or row-wise styles. 

**[Consolidate PP]**

This is mostly cosmetic change -- naming `TransformerStage` back to `Transformer`, moving `stage_idx` into `config` etc.