### PR TITLE
[Distributed] Enable sequence parallel

### DIFF
--- a/dist_run.py
+++ b/dist_run.py
@@ -75,18 +75,30 @@ def main():
         raise ValueError(f"Config file not found for model id {hf_model_name}")
     logger.info(f"Using HF model weights from {hf_model_name}")
 
-    mesh_dimensions = (2, 2)
-    device_mesh = _create_device_mesh(mesh_dimensions)
+    # Assuming 2 pipeline stages, feel free to change this as long as the
+    # asserts are satisfied
+    pp_degree = 2
+    assert world_size % pp_degree == 0
+    assert config.n_layers % pp_degree == 0
 
+    # Sequence parallel is enabled in this program
+    # Sequence parallel = Tensor parallel + dividing sequence by tp_degree at layer boundary
+    sp_degree = world_size // pp_degree
+
+    # Create device mesh
+    mesh_dimensions = (pp_degree, sp_degree)
+    device_mesh = _create_device_mesh(mesh_dimensions)
     tp_mesh = device_mesh["tp"]
     pp_mesh = device_mesh["pp"]
+    tp_rank = tp_mesh.get_local_rank()
     pp_rank = pp_mesh.get_local_rank()
-    nstages = pp_mesh.size()
-    device = torch.device(f"cuda:{rank}")
+
+    # Assuming same number of GPUs per node
+    device = torch.device(f"cuda:{rank % torch.cuda.device_count()}")
 
     # Fill in PP configs
     config.stage_idx = pp_rank
-    config.n_stages = nstages
+    config.n_stages = pp_degree
 
     with device:
         model = Transformer(config)
@@ -104,9 +116,10 @@ def main():
     batch_size = mbs * mb_size  # total batch size
     seqlen = 4096  # sequence length
     dim = 4096  # embedding dimension
+    assert seqlen % sp_degree == 0
 
     mb_ids = torch.randint(0, config.vocab_size, (mb_size, seqlen), device=device)
-    activation = torch.rand(mb_size, seqlen, dim, device=device, dtype=model_dtype)
+    activation = torch.rand(mb_size, seqlen // sp_degree, dim, device=device, dtype=model_dtype)
     example_args = mb_ids if pp_rank == 0 else activation
 
     # Load weights
@@ -115,11 +128,11 @@ def main():
 
     model.eval()
 
-    logger.info(f"Creating pipeline stage {pp_rank=}, {nstages=}")
+    logger.info(f"Creating pipeline stage {pp_rank=}, {pp_degree=}")
     stage = PipelineStage(
         model,
         pp_rank,
-        nstages,
+        pp_degree,
         device,
         input_args=(example_args,),
         group=pp_mesh.get_group(),
@@ -152,7 +165,9 @@ def main():
             schedule.step(input_ids)
         else:
             output = schedule.step()
-            logger.info(f"Output: {output}")
+
+    if pp_rank == pp_degree - 1 and tp_rank == 0:
+        logger.info(f"Output: {output}")
 
     logger.info(
         f"{color.green}Success{color.white} - {color.blue}Rank {rank} has completed.{color.reset}"

--- a/torchchat/model_dist.py
+++ b/torchchat/model_dist.py
@@ -10,12 +10,13 @@ import torch
 import torch.nn as nn
 
 from torch import Tensor
-from torch.distributed._tensor import Replicate
+from torch.distributed._tensor import Replicate, Shard, DTensor
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor.parallel import (
     ColwiseParallel,
     parallelize_module,
     RowwiseParallel,
+    SequenceParallel,
 )
 from torch.nn import functional as F
 
@@ -30,10 +31,6 @@ from torchchat.utils.build_utils import find_multiple
 
 config_path = Path(f"{str(Path(__file__).parent)}/known_model_params")
 
-
-# Use DTensor as output, by default
-Colwise = ColwiseParallel(use_local_output=False)
-Rowwise = RowwiseParallel(use_local_output=False)
 
 class Transformer(nn.Module):
     def __init__(self, config: TransformerArgs) -> None:
@@ -98,19 +95,27 @@ class Transformer(nn.Module):
     def distribute(self, device_mesh: DeviceMesh):
         if self.tok_embeddings:
             parallelize_module(
-                self.tok_embeddings,
-                device_mesh,
-                RowwiseParallel(input_layouts=Replicate()),
+                self.tok_embeddings, device_mesh,
+                RowwiseParallel(
+                    input_layouts=Replicate(),
+                    output_layouts=Shard(1),
+                ),
             )
+
         for layer in self.layers.values():
             layer.distribute(device_mesh)
-        # TODO (kwen2501) : parallelize these
-        """
+
         if self.norm:
-            parallelize_module(self.norm, device_mesh, ...)
+            parallelize_module(self.norm, device_mesh, SequenceParallel())
+
         if self.output:
-            parallelize_module(self.output, device_mesh, ...)
-        """
+            parallelize_module(
+                self.output, device_mesh,
+                ColwiseParallel(
+                    input_layouts=Shard(1),
+                    output_layouts=Replicate(),
+                ),
+            )
 
     def forward(self, x: Tensor, input_pos: Optional[Tensor] = None) -> Tensor:
         assert self.freqs_cis is not None, "Caches must be initialized first"
@@ -168,8 +173,8 @@ class TransformerBlock(nn.Module):
     def distribute(self, device_mesh: DeviceMesh):
         self.attention.distribute(device_mesh)
         self.feed_forward.distribute(device_mesh)
-        self.ffn_norm.distribute(device_mesh)
-        self.attention_norm.distribute(device_mesh)
+        parallelize_module(self.ffn_norm, device_mesh, SequenceParallel())
+        parallelize_module(self.attention_norm, device_mesh, SequenceParallel())
 
     def forward(
         self, x: Tensor, input_pos: Tensor, freqs_cis: Tensor, mask: Tensor
@@ -239,10 +244,11 @@ class Attention(nn.Module):
         _unfuse_wqkv_state_dict(state_dict, self.dim)
 
     def distribute(self, device_mesh: DeviceMesh):
-        parallelize_module(self.wq, device_mesh, Colwise)
-        parallelize_module(self.wk, device_mesh, Colwise)
-        parallelize_module(self.wv, device_mesh, Colwise)
-        parallelize_module(self.wo, device_mesh, Rowwise)
+        self.device_mesh = device_mesh
+        parallelize_module(self.wq, device_mesh, ColwiseParallel())
+        parallelize_module(self.wk, device_mesh, ColwiseParallel())
+        parallelize_module(self.wv, device_mesh, ColwiseParallel())
+        parallelize_module(self.wo, device_mesh, RowwiseParallel(output_layouts=Shard(1)))
 
     def forward(
         self,
@@ -251,13 +257,14 @@ class Attention(nn.Module):
         mask: Tensor,
         input_pos: Optional[Tensor] = None,
     ) -> Tensor:
+        if isinstance(x, DTensor):
+            x = x.redistribute(self.device_mesh, [Replicate()])
+
         bsz, seqlen, _ = x.shape
 
         q = self.wq(x)
         k = self.wk(x)
         v = self.wv(x)
-        # We use `to_local()` to convert DTensor back to regular Tensor
-        q, k, v = q.to_local(), k.to_local(), v.to_local()
         # kv_size = self.n_local_heads * self.head_dim
         # q, k, v = self.wqkv(x).split([self.dim, kv_size, kv_size], dim=-1)
 
@@ -280,9 +287,7 @@ class Attention(nn.Module):
 
         y = y.transpose(1, 2).contiguous().view(bsz, seqlen, -1)
 
-        y = self.wo(y)
-        # TODO: sequence parallelize this
-        return y.full_tensor()
+        return self.wo(y)
 
 
 class FeedForward(nn.Module):
@@ -293,17 +298,16 @@ class FeedForward(nn.Module):
         self.w3 = nn.Linear(config.dim, config.hidden_dim, bias=False)
 
     def distribute(self, device_mesh: DeviceMesh):
-        parallelize_module(self.w1, device_mesh, Colwise)
-        parallelize_module(self.w2, device_mesh, Rowwise)
-        parallelize_module(self.w3, device_mesh, Colwise)
+        self.device_mesh = device_mesh
+        parallelize_module(self.w1, device_mesh, ColwiseParallel())
+        parallelize_module(self.w2, device_mesh, RowwiseParallel(output_layouts=Shard(1)))
+        parallelize_module(self.w3, device_mesh, ColwiseParallel())
 
     def forward(self, x: Tensor) -> Tensor:
-        y = self.w2(F.silu(self.w1(x)) * self.w3(x))
-        # y is a DTensor with Partial placement;
-        # we convert its placement to Replicate and convert it back to a regular
-        # Tensor. `full_tensor` is the API that does both.
-        # TODO: sequence parallelize this
-        return y.full_tensor()
+        if isinstance(x, DTensor):
+            x = x.redistribute(self.device_mesh, [Replicate()])
+
+        return self.w2(F.silu(self.w1(x)) * self.w3(x))
 
 
 class RMSNorm(nn.Module):
@@ -311,13 +315,6 @@ class RMSNorm(nn.Module):
         super().__init__()
         self.eps = eps
         self.weight = nn.Parameter(torch.ones(dim))
-
-    def distribute(self, device_mesh: DeviceMesh):
-        # TODO (kwen2501): parallelize this
-        """
-        parallelize_module(self.weight, device_mesh, Colwise)
-        """
-        pass
 
     def _norm(self, x):
         return x * torch.rsqrt(torch.mean(x * x, dim=-1, keepdim=True) + self.eps)


### PR DESCRIPTION
Sequence parallel = Tensor parallel + dividing sequence by `tp_degree` at layer boundary

In addition to the op parallelism achieved by TP, SP reduces the activation size transferred between pipeline stages by `tp_degree`X.

The PR includes 4 parts:
1. Give SP styles to `parallelize_module` calls (this part mainly mimics what's used in torchtitan).
2. Before the attention layer, gather the sequence back.
3. Adjust example input to pipeline stages (divided by `tp_degree`).
4. Adjust the code for creating `input_pos` -- we still need to use the full seq length instead of `x.shape[1]` to create it bc `x` could have been cut in SP cases. 

Test:
`torchrun --nproc-per-node 8 dist_run.py`
(PP=2, TP=4)