### PR TITLE
[distributed] ensure precise rope embeddings by creating frequencies in bf16

### DIFF
--- a/dist_run.py
+++ b/dist_run.py
@@ -21,6 +21,7 @@ from distributed.safetensor_utils import (
 from distributed.utils import Color as color
 from torch.distributed.pipelining import PipelineStage, ScheduleGPipe
 from torchchat.model import ModelArgs, Transformer
+from torchchat.utils.build_utils import set_precision
 
 logger = setup_logging(__name__)
 
@@ -28,6 +29,7 @@ MODEL_NAME = "Transformer-2-7b-chat-hf"
 NAME_TO_HF_MODEL_ID_AND_DTYPE = {
     "Transformer-2-7b-chat-hf": ("meta-llama/Llama-2-7b-chat-hf", torch.float16),
 }
+CACHE_PRECISION = torch.bfloat16
 
 
 def _init_distributed():
@@ -80,6 +82,9 @@ def main():
     hf_model_name, model_dtype = NAME_TO_HF_MODEL_ID_AND_DTYPE[MODEL_NAME]
     logger.info(f"Using HF model weights from {hf_model_name} and dtype {model_dtype}")
 
+    set_precision(CACHE_PRECISION)
+    logger.info(f"Using cache precision {CACHE_PRECISION}")
+
     hf_config = get_hf_config_file(hf_model_name)
     if hf_config is None:
         raise ValueError(f"Config file not found for model id {hf_model_name}")
@@ -114,9 +119,7 @@ def main():
         model = Transformer(config)
 
     model.setup_caches(1, 4096)
-    # TODO: refine this .to once we start using fp8 for KV cache
-    model = model.to(model_dtype)
-
+    
     # Distribute model on TP mesh
     model.distribute(tp_mesh)
     logger.info(f"Model: {model}")

--- a/dist_run.py
+++ b/dist_run.py
@@ -119,7 +119,7 @@ def main():
         model = Transformer(config)
 
     model.setup_caches(1, 4096)
-    
+
     # Distribute model on TP mesh
     model.distribute(tp_mesh)
     logger.info(f"Model: {model}")


### PR DESCRIPTION
This PR:
1 - addresses and fixes a mismatch that was present in distributed model vs single gpu where the rope embeddings were not an exact match.  
example:
~~~

5.4030e-01, 8.4147e-01.  (distributed)
Vs
5.3906e-01,  8.3984e-01. (single gpu rope)

6.4791e-01, 7.6172e-01
Vs
6.4844e-01,  7.6172e-01

7.3176e-01, 6.8156e-01
Vs
7.3047e-01,  6.7969e-01
~~~

The issue was we were creating the frequencies float32, and then later setting the model (llama2) to float16 to match the checkpoint dtype. 

The fix is to use torchchat set_precision and set that to torch.bfloat16 so that all cache creation happens in torch.bfloat16 and thus expected rope embeddings precision.  
