### PR TITLE
Fix benchmarking statistics computation when profiler is used in generate.py

### DIFF
--- a/torchchat/generate.py
+++ b/torchchat/generate.py
@@ -834,6 +834,8 @@ class Generator:
                 generator_args.compile or generator_args.compile_prefill
             )
             compilation_time = time.perf_counter() - t0
+            device_sync(device=self.builder_args.device)
+            t = time.perf_counter() - t0
             if hasattr(prof, "export_chrome_trace"):
                 if self.builder_args.device == "cpu":
                     print(prof.key_averages().table(sort_by="self_cpu_time_total"))
@@ -843,8 +845,6 @@ class Generator:
                     prof.export_chrome_trace(f"{self.profile}_rank_{self.rank}.json")
                 else:
                     prof.export_chrome_trace(f"{self.profile}.json")
-            device_sync(device=self.builder_args.device)
-            t = time.perf_counter() - t0
 
             if start_pos >= max_seq_length:
                 print(


### PR DESCRIPTION
Currently, in `torchchat/generate.py`, benchmarking time includes time for printing the table & saving Chrome-viewable trace, so incorrect performance data for `Total throughput` and `Next token throughput` is being printed when the PyTorch profiler is enabled. The difference is significant (only verified on CPU. With int8 weight-only quantization, it resulted in a difference of 9 tokens/second, perhaps because I had also enabled shapes & memory profiling, which would've increased the size of the trace).

For verification, manually enabled profiling in `generate.py` because using `--profile` argument with `torchchat.py` did not work with HEAD commit 64510a33cd09b67b411e939ae0953d403724113c. I'm guessing its support is WIP.