### PR TITLE
[distributed] add gpu specs, % and absolute peak mem used per stage

### DIFF
--- a/dist_run.py
+++ b/dist_run.py
@@ -16,11 +16,14 @@ import torch.distributed as dist
 from torch.distributed.pipelining import PipelineStage, ScheduleGPipe
 
 from distributed.logging_utils import setup_logging
+
 # TODO - these are not distributed specific, consider moving to new package
-from distributed.safetensor_utils import (get_hf_config_file,
-                                          get_hf_weight_map_and_path,
-                                          load_safetensor_weights)
-from distributed.utils import Color as color
+from distributed.safetensor_utils import (
+    get_hf_config_file,
+    get_hf_weight_map_and_path,
+    load_safetensor_weights,
+)
+from distributed.utils import Color as color, build_gpu_memory_monitor
 from distributed.verification_utils import find_cpu_tensors
 from torchchat.cli.builder import TokenizerArgs, _initialize_tokenizer
 from torchchat.model import ModelArgs, Transformer
@@ -115,6 +118,9 @@ def _cleanup():
 
 def main():
     rank, world_size = _init_distributed()
+
+    gpu_memory_monitor, device_info = build_gpu_memory_monitor()
+    logger.info(f"{color.yellow} {device_info}{color.reset}")
 
     config = ModelArgs.from_name(MODEL_NAME).text_transformer_args
     logger.info(f"Chat Model Config: {config}")
@@ -230,6 +236,12 @@ def main():
 
     if pp_rank == pp_degree - 1 and tp_rank == 0:
         logger.info(f"Output: {output}")
+
+    # show peak memory stats for this stage
+    res_mem_gib, res_mem_pct = gpu_memory_monitor.get_peak_stats()
+    logger.info(
+        f"{color.blue} Memory used: {color.green}{res_mem_pct:.3f} %, {color.magenta}{res_mem_gib:.3f} GB{color.reset}"
+    )
 
     logger.info(
         f"{color.green}Success{color.white} - {color.blue}Rank {rank} has completed.{color.reset}"

--- a/dist_run.py
+++ b/dist_run.py
@@ -23,7 +23,7 @@ from distributed.safetensor_utils import (
     get_hf_weight_map_and_path,
     load_safetensor_weights,
 )
-from distributed.utils import Color as color, build_gpu_memory_monitor
+from distributed.utils import Color as color, GPUMemoryMonitor
 from distributed.verification_utils import find_cpu_tensors
 from torchchat.cli.builder import TokenizerArgs, _initialize_tokenizer
 from torchchat.model import ModelArgs, Transformer
@@ -119,8 +119,8 @@ def _cleanup():
 def main():
     rank, world_size = _init_distributed()
 
-    gpu_memory_monitor, device_info = build_gpu_memory_monitor()
-    logger.info(f"{color.yellow} {device_info}{color.reset}")
+    gpu_memory_monitor = GPUMemoryMonitor("cuda")
+    logger.info(f"{color.yellow} {gpu_memory_monitor.get_device_info()}{color.reset}")
 
     config = ModelArgs.from_name(MODEL_NAME).text_transformer_args
     logger.info(f"Chat Model Config: {config}")

--- a/distributed/parallel_config.py
+++ b/distributed/parallel_config.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from torch.distributed.device_mesh import init_device_mesh
 
 from distributed.logging_utils import setup_logging
-
+logger = setup_logging(__name__)
 
 @dataclass
 class ParallelDims:

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -81,10 +81,10 @@ class NoColor:
 
 
 class GPUMemoryMonitor:
-    def __init__(self, device: str = "cuda:0"):
+    def __init__(self, device: str):
         self.device = torch.device(device)  # device object
         self.device_name = torch.cuda.get_device_name(self.device)
-        self.device_index = torch.cuda.current_device()
+        self.device_index = self.device.index
         self.device_capacity = torch.cuda.get_device_properties(
             self.device
         ).total_memory
@@ -105,10 +105,6 @@ class GPUMemoryMonitor:
     def get_peak_stats(self):
         cuda_info = torch.cuda.memory_stats(self.device)
 
-        # max_active = cuda_info["active_bytes.all.peak"]
-        # max_active_gib = self._to_gib(max_active)
-        # max_active_pct = self._to_pct(max_active)
-
         max_reserved = cuda_info["reserved_bytes.all.peak"]
         max_reserved_gib = self._to_gib(max_reserved)
         max_reserved_pct = self._to_pct(max_reserved)
@@ -118,12 +114,12 @@ class GPUMemoryMonitor:
     def reset_peak_stats(self):
         torch.cuda.reset_peak_memory_stats()
 
-
-def build_gpu_memory_monitor():
-    gpu_memory_monitor = GPUMemoryMonitor("cuda")
-    device_info = (
-        f"GPU capacity: {gpu_memory_monitor.device_name} ({gpu_memory_monitor.device_index}) "
-        f"with {gpu_memory_monitor.device_capacity_gib:.2f}GiB memory"
-    )
-
-    return gpu_memory_monitor, device_info
+    def get_device_info(
+        self,
+    ) -> str:
+        """provides a single formatted string detailing device name, index and total memory"""
+        device_info = (
+            f"GPU capacity: {self.device_name} ({self.device_index}) "
+            f"with {self.device_capacity_gib:.2f}GiB memory"
+        )
+        return device_info

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -14,12 +14,14 @@ from distributed.logging_utils import setup_logging
 
 logger = setup_logging(__name__)
 
+
 def _warn_overwrite_env(env, val):
     if env in os.environ:
         logger.warning(
             f"ENV[{env}] = {os.environ[env]} will be overridden to {val} based on job config"
         )
     os.environ[env] = val
+
 
 TRACE_BUFFER_SIZE = "TORCH_NCCL_TRACE_BUFFER_SIZE"
 TRACE_FILE = "TORCH_NCCL_DEBUG_INFO_TEMP_FILE"
@@ -76,3 +78,52 @@ class NoColor:
     cyan = ""
     white = ""
     reset = ""
+
+
+class GPUMemoryMonitor:
+    def __init__(self, device: str = "cuda:0"):
+        self.device = torch.device(device)  # device object
+        self.device_name = torch.cuda.get_device_name(self.device)
+        self.device_index = torch.cuda.current_device()
+        self.device_capacity = torch.cuda.get_device_properties(
+            self.device
+        ).total_memory
+        self.device_capacity_gib = self._to_gib(self.device_capacity)
+
+        torch.cuda.reset_peak_memory_stats()
+        torch.cuda.empty_cache()
+
+    def _to_gib(self, memory_in_bytes):
+        # NOTE: GiB (gibibyte) is 1024, vs GB is 1000
+        _gib_in_bytes = 1024 * 1024 * 1024
+        memory_in_gib = memory_in_bytes / _gib_in_bytes
+        return memory_in_gib
+
+    def _to_pct(self, memory):
+        return 100 * memory / self.device_capacity
+
+    def get_peak_stats(self):
+        cuda_info = torch.cuda.memory_stats(self.device)
+
+        # max_active = cuda_info["active_bytes.all.peak"]
+        # max_active_gib = self._to_gib(max_active)
+        # max_active_pct = self._to_pct(max_active)
+
+        max_reserved = cuda_info["reserved_bytes.all.peak"]
+        max_reserved_gib = self._to_gib(max_reserved)
+        max_reserved_pct = self._to_pct(max_reserved)
+
+        return max_reserved_gib, max_reserved_pct
+
+    def reset_peak_stats(self):
+        torch.cuda.reset_peak_memory_stats()
+
+
+def build_gpu_memory_monitor():
+    gpu_memory_monitor = GPUMemoryMonitor("cuda")
+    device_info = (
+        f"GPU capacity: {gpu_memory_monitor.device_name} ({gpu_memory_monitor.device_index}) "
+        f"with {gpu_memory_monitor.device_capacity_gib:.2f}GiB memory"
+    )
+
+    return gpu_memory_monitor, device_info


### PR DESCRIPTION
This PR:
1 - adds a GPUMemoryMonitor class to:

a - log the gpus' device capabilities at start of run (in yellow):
<img width="798" alt="Screenshot 2024-09-08 at 5 23 59 PM" src="https://github.com/user-attachments/assets/f795182a-0df8-447b-84e9-56782bb1d57a">

b - at the end of the run, show the absolute peak res memory as well as % peak memory used per stage:
<img width="539" alt="Screenshot 2024-09-08 at 5 23 07 PM" src="https://github.com/user-attachments/assets/dbac5c53-89f0-4ca7-b609-5c5aa6975cfe">
