### PR TITLE
[distributed] add stage metrics - total params per stage, total size and present it in a nicely formatted manner

### DIFF
--- a/dist_run.py
+++ b/dist_run.py
@@ -23,7 +23,12 @@ from distributed.safetensor_utils import (
     get_hf_weight_map_and_path,
     load_safetensor_weights,
 )
-from distributed.utils import Color as color, get_module_size, get_num_params, bytes_to_readable
+from distributed.utils import (
+    Color as color,
+    get_module_size,
+    get_num_params,
+    bytes_to_readable,
+)
 from distributed.verification_utils import find_cpu_tensors
 from torchchat.cli.builder import TokenizerArgs, _initialize_tokenizer
 from torchchat.model import ModelArgs, Transformer
@@ -194,7 +199,7 @@ def main():
     logger.info(
         f"Stage {rank} has {color.blue}{stage_num_params} params{color.reset}, Size: {color.blue}{stage_size_formatted}{color.reset}\n"
     )
-    assert False, "check formatted"
+
     # Setup input position
     # input_pos for prefill: a list of increasing integers from 0 to seqlen
     input_pos = torch.arange(seqlen, device=device)

--- a/dist_run.py
+++ b/dist_run.py
@@ -23,7 +23,7 @@ from distributed.safetensor_utils import (
     get_hf_weight_map_and_path,
     load_safetensor_weights,
 )
-from distributed.utils import Color as color, get_stage_size, get_num_params
+from distributed.utils import Color as color, get_module_size, get_num_params, bytes_to_readable
 from distributed.verification_utils import find_cpu_tensors
 from torchchat.cli.builder import TokenizerArgs, _initialize_tokenizer
 from torchchat.model import ModelArgs, Transformer
@@ -188,12 +188,13 @@ def main():
     _load_model_weights(model, hf_model_name, device=device, model_config=config)
 
     # info on stage size and params
-    stage_size, stage_size_formatted = get_stage_size(model)
+    stage_size = get_module_size(model)
+    stage_size_formatted = bytes_to_readable(stage_size)
     stage_num_params = get_num_params(model)
     logger.info(
         f"Stage {rank} has {color.blue}{stage_num_params} params{color.reset}, Size: {color.blue}{stage_size_formatted}{color.reset}\n"
     )
-
+    assert False, "check formatted"
     # Setup input position
     # input_pos for prefill: a list of increasing integers from 0 to seqlen
     input_pos = torch.arange(seqlen, device=device)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -56,7 +56,8 @@ def get_num_params(model: torch.nn.Module, exclude_embedding: bool = False) -> i
     return readable_num_params
 
 
-def get_module_size(stage):
+def get_module_size(stage: torch.nn.Module) -> int:
+    """get module (stage) size in bytes"""
     model_size = sum(
         [
             p.numel() * p.dtype.itemsize

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -56,15 +56,14 @@ def get_num_params(model: torch.nn.Module, exclude_embedding: bool = False) -> i
     return readable_num_params
 
 
-def get_stage_size(stage):
+def get_module_size(stage):
     model_size = sum(
         [
             p.numel() * p.dtype.itemsize
             for p in itertools.chain(stage.parameters(), stage.buffers())
         ]
     )
-    readable_model_size = bytes_to_readable(model_size)
-    return model_size, readable_model_size
+    return model_size
 
 
 def format_model_params(params):

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import itertools
 import os
 from dataclasses import dataclass
 from datetime import timedelta
@@ -14,12 +15,14 @@ from distributed.logging_utils import setup_logging
 
 logger = setup_logging(__name__)
 
+
 def _warn_overwrite_env(env, val):
     if env in os.environ:
         logger.warning(
             f"ENV[{env}] = {os.environ[env]} will be overridden to {val} based on job config"
         )
     os.environ[env] = val
+
 
 TRACE_BUFFER_SIZE = "TORCH_NCCL_TRACE_BUFFER_SIZE"
 TRACE_FILE = "TORCH_NCCL_DEBUG_INFO_TEMP_FILE"
@@ -49,7 +52,47 @@ def get_num_params(model: torch.nn.Module, exclude_embedding: bool = False) -> i
     num_params = sum(p.numel() for p in model.parameters())
     if exclude_embedding:
         num_params -= model.tok_embeddings.weight.numel()
-    return num_params
+    readable_num_params = format_model_params(num_params)
+    return readable_num_params
+
+
+def get_stage_size(stage):
+    model_size = sum(
+        [
+            p.numel() * p.dtype.itemsize
+            for p in itertools.chain(stage.parameters(), stage.buffers())
+        ]
+    )
+    readable_model_size = bytes_to_readable(model_size)
+    return model_size, readable_model_size
+
+
+def format_model_params(params):
+    """turn the num_params into a readable formatted number"""
+    if params >= 1_000_000_000:
+        return f"{params / 1_000_000_000:.2f}B"
+    elif params >= 1_000_000:
+        return f"{params / 1_000_000:.2f}M"
+    else:
+        return f"{params:,}"
+
+
+def bytes_to_readable(bytes_value: int, round_to: int = 2) -> str:
+    """formatting function to make reading model (stage) sizes easy"""
+    GiB = 1024**3  # 1 GiB in bytes
+    MiB = 1024**2  # 1 MiB in bytes
+
+    if bytes_value >= GiB:
+        value = bytes_value / GiB
+        unit = "GiB"
+    else:
+        value = bytes_value / MiB
+        unit = "MiB"
+
+    # Round to 2 decimal places
+    rounded_value = round(value, round_to)
+
+    return f"{rounded_value} {unit}"
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
This PR:
1 - computes the total params per stage and total byte size, and presents that in a nicely formatted manner:

<img width="1067" alt="Screenshot 2024-09-08 at 5 46 00 PM" src="https://github.com/user-attachments/assets/5c8f832f-c1a5-4de7-9d1b-adfe78742880">

There are four underlying functions supporting this - one each for getting the relevant data, and then one each for formatting it nicely into a nice human readable format. 

The result is we can quickly monitor / verify that stages are relatively balanced in params / size. 