### PR TITLE
[distributed] add TrackTime, CUDATrackTime to monitor perf for weight loading per stage and future perf measurements

### DIFF
--- a/dist_run.py
+++ b/dist_run.py
@@ -16,11 +16,14 @@ import torch.distributed as dist
 from torch.distributed.pipelining import PipelineStage, ScheduleGPipe
 
 from distributed.logging_utils import setup_logging
+
 # TODO - these are not distributed specific, consider moving to new package
-from distributed.safetensor_utils import (get_hf_config_file,
-                                          get_hf_weight_map_and_path,
-                                          load_safetensor_weights)
-from distributed.utils import Color as color
+from distributed.safetensor_utils import (
+    get_hf_config_file,
+    get_hf_weight_map_and_path,
+    load_safetensor_weights,
+)
+from distributed.utils import Color as color, TrackTime
 from distributed.verification_utils import find_cpu_tensors
 from torchchat.cli.builder import TokenizerArgs, _initialize_tokenizer
 from torchchat.model import ModelArgs, Transformer
@@ -182,7 +185,12 @@ def main():
 
     # Load weights
     logger.info(f"Loading weights for {pp_rank=} on {device=}")
-    _load_model_weights(model, hf_model_name, device=device, model_config=config)
+    with TrackTime() as timer:
+        _load_model_weights(model, hf_model_name, device=device, model_config=config)
+
+    logger.info(
+        f"{color.green}Total weight loading time: {timer.get_time()} {timer.unit} for stage {rank}{color.reset}"
+    )
 
     # Setup input position
     # input_pos for prefill: a list of increasing integers from 0 to seqlen

--- a/dist_run.py
+++ b/dist_run.py
@@ -185,13 +185,13 @@ def main():
 
     # Load weights
     logger.info(f"Loading weights for {pp_rank=} on {device=}")
-    with CUDATrackTime("cuda") as timer:
+    with TrackTime("cuda") as timer:
         _load_model_weights(model, hf_model_name, device=device, model_config=config)
 
     logger.info(
         f"{color.green}Total weight loading time: {timer.get_time()} {timer.unit} for stage {rank}{color.reset}"
     )
-    assert False, "check time"
+    
     
     # Setup input position
     # input_pos for prefill: a list of increasing integers from 0 to seqlen

--- a/dist_run.py
+++ b/dist_run.py
@@ -23,7 +23,7 @@ from distributed.safetensor_utils import (
     get_hf_weight_map_and_path,
     load_safetensor_weights,
 )
-from distributed.utils import Color as color, TrackTime
+from distributed.utils import Color as color, TrackTime, CUDATrackTime
 from distributed.verification_utils import find_cpu_tensors
 from torchchat.cli.builder import TokenizerArgs, _initialize_tokenizer
 from torchchat.model import ModelArgs, Transformer
@@ -191,7 +191,7 @@ def main():
     logger.info(
         f"{color.green}Total weight loading time: {timer.get_time()} {timer.unit} for stage {rank}{color.reset}"
     )
-
+    
     # Setup input position
     # input_pos for prefill: a list of increasing integers from 0 to seqlen
     input_pos = torch.arange(seqlen, device=device)

--- a/dist_run.py
+++ b/dist_run.py
@@ -185,12 +185,13 @@ def main():
 
     # Load weights
     logger.info(f"Loading weights for {pp_rank=} on {device=}")
-    with TrackTime() as timer:
+    with CUDATrackTime("cuda") as timer:
         _load_model_weights(model, hf_model_name, device=device, model_config=config)
 
     logger.info(
         f"{color.green}Total weight loading time: {timer.get_time()} {timer.unit} for stage {rank}{color.reset}"
     )
+    assert False, "check time"
     
     # Setup input position
     # input_pos for prefill: a list of increasing integers from 0 to seqlen

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -112,8 +112,11 @@ class TrackTime:
 
 
 class CUDATrackTime:
-    """integrated class for perf timing via cuda events.
-    Note - this uses a default stream synchronize, and defaults to current device."""
+    """
+    Integrated class for perf timing via cuda events.
+    Note - this uses the default stream to synchronize, and defaults to current device.
+    The event.record() will create a context on the CUDA device matching the device used at init.
+    """
 
     def __init__(self, device=None, use_ms: bool = False, round_to: Optional[int] = 4):
         if device is None:

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -139,7 +139,7 @@ class CUDATrackTime:
         if self.active:
             raise RuntimeError("Timer is still running. Use .stop() to stop it")
 
-        torch.cuda.synchronize() # Wait for all GPU operations to finish
+        torch.cuda.synchronize()  # Wait for all GPU operations to finish
         total_time = self.start_event.elapsed_time(self.end_event)
 
         if not self.use_ms:


### PR DESCRIPTION
This PR:
1 - adds a TrackTimer class to wrap perf_counter and make it easy to do perf timings.
2 - implements it to track weight loading time per stage:

<img width="1067" alt="Screenshot 2024-09-08 at 6 22 53 PM" src="https://github.com/user-attachments/assets/fee06915-7c41-4216-9bbb-a3499b611c90">

Note - there is a similar timer class called measure_time in chat, but I added some additional rounding options,  unit options and also didn't want to use print for the logging. 

