### PR TITLE
[distributed] add SingletonLogger to avoid duplicate logging, with custom formatting options including file name: line_number

### DIFF
--- a/dist_run.py
+++ b/dist_run.py
@@ -16,10 +16,13 @@ import torch.distributed as dist
 from torch.distributed.pipelining import PipelineStage, ScheduleGPipe
 
 from distributed.logging_utils import SingletonLogger
+
 # TODO - these are not distributed specific, consider moving to new package
-from distributed.safetensor_utils import (get_hf_config_file,
-                                          get_hf_weight_map_and_path,
-                                          load_safetensor_weights)
+from distributed.safetensor_utils import (
+    get_hf_config_file,
+    get_hf_weight_map_and_path,
+    load_safetensor_weights,
+)
 from distributed.utils import Color as color
 from distributed.verification_utils import find_cpu_tensors
 from torchchat.cli.builder import TokenizerArgs, _initialize_tokenizer

--- a/dist_run.py
+++ b/dist_run.py
@@ -15,7 +15,7 @@ import torch
 import torch.distributed as dist
 from torch.distributed.pipelining import PipelineStage, ScheduleGPipe
 
-from distributed.logging_utils import setup_logging
+from distributed.logging_utils import SingletonLogger
 # TODO - these are not distributed specific, consider moving to new package
 from distributed.safetensor_utils import (get_hf_config_file,
                                           get_hf_weight_map_and_path,
@@ -36,7 +36,7 @@ except ImportError:
     SentencePieceProcessor = None
 
 
-logger = setup_logging(__name__)
+logger = SingletonLogger.get_logger()
 
 MODEL_NAME = "Transformer-2-7b-chat-hf"
 NAME_TO_HF_MODEL_ID_AND_DTYPE = {

--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from distributed.checkpoint import load_checkpoints_to_model
-from distributed.logging_utils import setup_logging
+from distributed.logging_utils import SingletonLogger
 from distributed.parallel_config import ParallelDims
 from distributed.parallelize_llama import parallelize_llama
 from distributed.utils import init_distributed

--- a/distributed/config_manager.py
+++ b/distributed/config_manager.py
@@ -12,9 +12,9 @@ from typing import Tuple
 
 import torch
 
-from distributed.logging_utils import setup_logging
+from distributed.logging_utils import SingletonLogger
+logger = SingletonLogger.get_logger()
 
-logger = setup_logging(__name__)
 
 try:
     import tomllib

--- a/distributed/dtensor_utils.py
+++ b/distributed/dtensor_utils.py
@@ -1,10 +1,12 @@
 import torch
 from torch.distributed._tensor import DTensor, Shard, Replicate
 
-from distributed.logging_utils import setup_logging
+
 from collections import defaultdict
 
-logger = setup_logging(__name__)
+from distributed.logging_utils import SingletonLogger
+logger = SingletonLogger.get_logger()
+
 
 
 def is_dtensor(tensor):

--- a/distributed/logging_utils.py
+++ b/distributed/logging_utils.py
@@ -7,7 +7,83 @@
 import logging
 import os
 from datetime import datetime
+from typing import Optional
 
+
+def millisecond_timestamp(include_year: bool = False) -> str:
+    format_string = '%Y-%m-%d %H:%M:%S.%f' if include_year else '%m-%d %H:%M:%S.%f'
+    return datetime.now().strftime(format_string)[:-3]
+
+class CompactFormatter(logging.Formatter):
+    def __init__(self, fmt: Optional[str] = None, datefmt: Optional[str] = None, style: str = '%',
+                 validate: bool = True, *, defaults: Optional[dict] = None, show_lower_levels: bool = True):
+        super().__init__(fmt, datefmt, style, validate, defaults=defaults)
+        self.show_lower_levels = show_lower_levels
+        self.original_fmt = fmt
+
+    def format(self, record: logging.LogRecord) -> str:
+        # Remove .py extension from filename
+        record.filename = os.path.splitext(record.filename)[0]
+        
+        if self.show_lower_levels or record.levelno > logging.INFO:
+            return super().format(record)
+        else:
+            # Create a copy of the record and modify it
+            new_record = logging.makeLogRecord(record.__dict__)
+            new_record.levelname = ''
+            # Temporarily change the format string
+            temp_fmt = self.original_fmt.replace(' - %(levelname)s', '')
+            self._style._fmt = temp_fmt
+            formatted_message = super().format(new_record)
+            # Restore the original format string
+            self._style._fmt = self.original_fmt
+            return formatted_message
+
+class SingletonLogger:
+    """Singleton (global) logger to avoid logging duplication"""
+    _instance = None
+
+    @classmethod
+    def get_logger(cls, name: str = 'global_logger', level: int = logging.INFO,
+                   include_year: bool = False, show_lower_levels: bool = False) -> logging.Logger:
+        """
+        Get or create a singleton logger instance.
+
+        :param name: Name of the logger
+        :param level: Logging level
+        :param include_year: Whether to include the year in timestamps
+        :param show_lower_levels: Whether to show level names for INFO and DEBUG messages
+        :return: Logger instance
+        """
+        if cls._instance is None:
+            cls._instance = cls._setup_logger(name, level, include_year, show_lower_levels)
+        return cls._instance
+
+    @staticmethod
+    def _setup_logger(name: str, level: int, include_year: bool = False, show_lower_levels: bool = False) -> logging.Logger:
+        logger = logging.getLogger(name)
+        
+        if not logger.handlers:
+            logger.setLevel(level)
+            
+            console_handler = logging.StreamHandler()
+            console_handler.setLevel(level)
+            
+            formatter = CompactFormatter(
+                '%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s',
+                show_lower_levels=show_lower_levels
+            )
+            formatter.formatTime = lambda record, datefmt=None: millisecond_timestamp(include_year)
+            console_handler.setFormatter(formatter)
+            logger.addHandler(console_handler)
+            
+            # Suppress verbose torch.profiler logging
+            os.environ["KINETO_LOG_LEVEL"] = "5"
+        
+        logger.propagate = False
+        return logger
+
+'''
 def millisecond_timestamp(*args):
     return datetime.now().strftime('%m-%d %H:%M:%S.%f')[:-3]
 
@@ -29,3 +105,4 @@ def setup_logging(name=None, log_level=logging.INFO):
         os.environ["KINETO_LOG_LEVEL"] = "5"
 
     return logger
+'''

--- a/distributed/parallel_config.py
+++ b/distributed/parallel_config.py
@@ -8,7 +8,8 @@ from dataclasses import dataclass
 
 from torch.distributed.device_mesh import init_device_mesh
 
-from distributed.logging_utils import setup_logging
+from distributed.logging_utils import SingletonLogger
+logger = SingletonLogger.get_logger()
 
 
 @dataclass

--- a/distributed/parallelize_llama.py
+++ b/distributed/parallelize_llama.py
@@ -10,10 +10,11 @@ from torch.distributed.tensor.parallel import (ColwiseParallel,
                                                RowwiseParallel,
                                                parallelize_module)
 
-from distributed.logging_utils import setup_logging
+
 from distributed.parallel_config import ParallelDims
 
-logger = setup_logging(__name__)
+from distributed.logging_utils import SingletonLogger
+logger = SingletonLogger.get_logger()
 
 
 def apply_tp(

--- a/distributed/safetensor_utils.py
+++ b/distributed/safetensor_utils.py
@@ -13,14 +13,17 @@ import json
 from torch.nn import Module
 from typing import Dict, Tuple, Set, Optional
 
-from distributed.logging_utils import setup_logging
+
 from distributed.dtensor_utils import is_dtensor, load_into_dtensor
 
 
 _DEFAULT_SAFETENSOR_FILE_NAME = "model.safetensors.index.json"
 _CONFIG_NAME = "config.json"
 
-logger = setup_logging(__name__)
+
+from distributed.logging_utils import SingletonLogger
+logger = SingletonLogger.get_logger()
+
 
 
 def compare_and_reverse(tensor1: torch.Tensor, tensor2: torch.Tensor) -> torch.Tensor:

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -10,9 +10,9 @@ from datetime import timedelta
 
 import torch
 
-from distributed.logging_utils import setup_logging
 
-logger = setup_logging(__name__)
+from distributed.logging_utils import SingletonLogger
+logger = SingletonLogger.get_logger()
 
 def _warn_overwrite_env(env, val):
     if env in os.environ:

--- a/distributed/verification_utils.py
+++ b/distributed/verification_utils.py
@@ -6,9 +6,10 @@ from torch._subclasses import FakeTensor
 import numpy as np
 from distributed.dtensor_utils import is_dtensor
 from typing import Dict, List, Tuple
-from distributed.logging_utils import setup_logging
 
-logger = setup_logging(__name__)
+from distributed.logging_utils import SingletonLogger
+logger = SingletonLogger.get_logger()
+
 
 
 def record_module_dtypes(module):

--- a/distributed/world_maker.py
+++ b/distributed/world_maker.py
@@ -9,13 +9,16 @@ from typing import Optional, Tuple
 
 from torch.distributed.device_mesh import DeviceMesh
 
-from distributed.logging_utils import setup_logging
+
 from distributed.parallel_config import ParallelDims
 from distributed.utils import init_distributed
 
 from .config_manager import InferenceConfig
 
-logger = setup_logging(__name__)
+
+from distributed.logging_utils import SingletonLogger
+logger = SingletonLogger.get_logger()
+
 
 def launch_distributed(
     toml_config: str,


### PR DESCRIPTION
This PR:
1 - adds a new SingletonLogger to eliminate an issue that was popping up with duplicate logging. 

Before:
<img width="1139" alt="Screenshot 2024-09-09 at 2 28 43 PM" src="https://github.com/user-attachments/assets/706a1b1f-f2a4-4069-a4fa-b7e85a218001">


After:

<img width="1257" alt="Screenshot 2024-09-09 at 7 27 44 PM" src="https://github.com/user-attachments/assets/37400cc5-a9af-482a-8d1b-2920248963a9">


2 - This logger adds a couple useful formatting improvements:

    a - option to not display the year in the timestamp to save space
    b - avoid putting INFO / DEBUG for the level, again to save space (WARNING / ERROR / CRITICAL) are always shown
    c - shows the calling filename and line number even though this is now a singleton setup
    d - strips ".py" extension so that it's filename:line_number and not filename.py:line_number, again to save space.


