### PR TITLE
Add missing Block size + Update Configs to not hardcode rope_scaling

### DIFF
--- a/torchchat/model.py
+++ b/torchchat/model.py
@@ -682,7 +682,9 @@ class RMSNorm(nn.Module):
 
 def apply_scaling(freqs: torch.Tensor, rope_scaling: Dict[str, Any]):
     # Check for the presence of the required keys
-    assert set(rope_scaling.keys()) >= {"factor", "low_freq_factor", "high_freq_factor", "original_max_position_embeddings"}
+    required_keys = {"factor", "low_freq_factor", "high_freq_factor", "original_max_position_embeddings"}
+    if not required_keys.issubset(rope_scaling.keys()):
+        raise ValueError(f"Missing required keys in apply_scaling. Expected: {required_keys}")
 
     scale_factor = rope_scaling["factor"]
     low_freq_factor = rope_scaling["low_freq_factor"]

--- a/torchchat/model_params/Meta-Llama-3-70B.json
+++ b/torchchat/model_params/Meta-Llama-3-70B.json
@@ -1,1 +1,1 @@
-{"dim": 8192, "ffn_dim_multiplier": 1.3, "multiple_of": 4096, "n_heads": 64, "n_local_heads": 8, "n_layers": 80, "rope_base": 500000.0, "vocab_size": 128256, "use_tiktoken": true}
+{"block_size": 8192, "dim": 8192, "ffn_dim_multiplier": 1.3, "multiple_of": 4096, "n_heads": 64, "n_local_heads": 8, "n_layers": 80, "rope_base": 500000.0, "vocab_size": 128256, "use_tiktoken": true}

--- a/torchchat/model_params/Meta-Llama-3-8B.json
+++ b/torchchat/model_params/Meta-Llama-3-8B.json
@@ -1,1 +1,1 @@
-{"dim": 4096, "ffn_dim_multiplier": 1.3, "multiple_of": 1024, "n_heads": 32, "n_local_heads": 8, "n_layers": 32, "rope_base": 500000.0, "vocab_size": 128256, "use_tiktoken": true}
+{"block_size": 8192, "dim": 4096, "ffn_dim_multiplier": 1.3, "multiple_of": 1024, "n_heads": 32, "n_local_heads": 8, "n_layers": 32, "rope_base": 500000.0, "vocab_size": 128256, "use_tiktoken": true}

--- a/torchchat/model_params/Meta-Llama-3.1-70B.json
+++ b/torchchat/model_params/Meta-Llama-3.1-70B.json
@@ -1,1 +1,1 @@
-{"dim": 8192, "ffn_dim_multiplier": 1.3, "multiple_of": 4096, "n_heads": 64, "n_local_heads": 8, "n_layers": 80, "rope_base": 500000.0, "vocab_size": 128256, "use_tiktoken": true, "norm_eps": 1e-05, "use_scaled_rope": true}
+{"block_size": 131072, "dim": 8192, "ffn_dim_multiplier": 1.3, "multiple_of": 4096, "n_heads": 64, "n_local_heads": 8, "n_layers": 80, "rope_base": 500000.0, "vocab_size": 128256, "use_tiktoken": true, "norm_eps": 1e-05, "rope_scaling": {"factor": 8.0, "low_freq_factor": 1.0, "high_freq_factor": 4.0, "original_max_position_embeddings": 8192}}

--- a/torchchat/model_params/Meta-Llama-3.1-8B.json
+++ b/torchchat/model_params/Meta-Llama-3.1-8B.json
@@ -1,1 +1,1 @@
-{"dim": 4096, "ffn_dim_multiplier": 1.3, "multiple_of": 1024, "n_heads": 32, "n_local_heads": 8, "n_layers": 32, "rope_base": 500000.0, "vocab_size": 128256, "use_tiktoken": true, "norm_eps": 1e-05, "use_scaled_rope": true}
+{"block_size": 131072, "dim": 4096, "ffn_dim_multiplier": 1.3, "multiple_of": 1024, "n_heads": 32, "n_local_heads": 8, "n_layers": 32, "rope_base": 500000.0, "vocab_size": 128256, "use_tiktoken": true, "norm_eps": 1e-05, "rope_scaling": {"factor": 8.0, "low_freq_factor": 1.0, "high_freq_factor": 4.0, "original_max_position_embeddings": 8192}}


### PR DESCRIPTION
1) Previously the block_size was not being included in the model_params.json of llama3/3.1 models so it just used a hard coded 2048. This PR adds them into the config.

2) For rope_scaling (llama 3.1), we were hardcoding the parameters inside of `apply_scaling()` instead of taking them in as TransformerArgs built from model_params. These happen to line up for 3.1, but this PR makes them an explicit read