### PR TITLE
bump ao to 0.5.0 to enable torchtune across platforms

### DIFF
--- a/install/install_requirements.sh
+++ b/install/install_requirements.sh
@@ -95,6 +95,11 @@ LINUX_REQUIREMENTS_TO_INSTALL=(
 )
 
 PLATFORM=$(uname -s)
+
+# Install torchtune and torchao requirements for Linux systems using nightly.
+# For non-Linux systems (e.g., macOS), install torchao from GitHub since nightly
+# build doesn't have macOS build.
+# TODO: Remove this and install nightly build, once it supports macOS
 if [ "$PLATFORM" == "Linux" ];
 then
   (

--- a/install/install_requirements.sh
+++ b/install/install_requirements.sh
@@ -95,11 +95,19 @@ LINUX_REQUIREMENTS_TO_INSTALL=(
 )
 
 PLATFORM=$(uname -s)
-if [ "$PLATFORM" == "Linux" ]; then
+if [ "$PLATFORM" == "Linux" ];
+then
   (
     set -x
     $PIP_EXECUTABLE install --pre --extra-index-url "${TORCH_NIGHTLY_URL}" --no-cache-dir \
       "${LINUX_REQUIREMENTS_TO_INSTALL[@]}"
+  )
+else
+  # For torchao need to install from github since nightly build doesn't have macos build.
+  # TODO: Remove this and install nightly build, once it supports macos
+  (
+    set -x
+    $PIP_EXECUTABLE install git+https://github.com/pytorch/ao.git@e11201a62669f582d81cdb33e031a07fb8dfc4f3
   )
 fi
 

--- a/install/install_requirements.sh
+++ b/install/install_requirements.sh
@@ -88,7 +88,8 @@ REQUIREMENTS_TO_INSTALL=(
 )
 
 (
-  set -x $PIP_EXECUTABLE install torchao=="0.5.0"
+  set -x
+  $PIP_EXECUTABLE install torchao=="0.5.0"
 )
 
 if [[ -x "$(command -v nvidia-smi)" ]]; then

--- a/install/install_requirements.sh
+++ b/install/install_requirements.sh
@@ -41,13 +41,23 @@ fi
 )
 
 # Since torchchat often uses main-branch features of pytorch, only the nightly
-# pip versions will have the required features. The NIGHTLY_VERSION value should
+# pip versions will have the required features. The PYTORCH_NIGHTLY_VERSION value should
 # agree with the third-party/pytorch pinned submodule commit.
 #
 # NOTE: If a newly-fetched version of the executorch repo changes the value of
-# NIGHTLY_VERSION, you should re-run this script to install the necessary
+# PYTORCH_NIGHTLY_VERSION, you should re-run this script to install the necessary
 # package versions.
-NIGHTLY_VERSION=dev20240814
+PYTORCH_NIGHTLY_VERSION=dev20240814
+
+# Nightly version for torchvision
+VISION_NIGHTLY_VERSION=dev20240814
+
+# Nightly version for torchao
+AO_NIGHTLY_VERSION=dev20240905
+
+# Nightly version for torchtune
+TUNE_NIGHTLY_VERSION=dev20240910
+
 
 # Uninstall triton, as nightly will depend on pytorch-triton, which is one and the same
 (
@@ -67,10 +77,16 @@ fi
 
 # pip packages needed by exir.
 REQUIREMENTS_TO_INSTALL=(
-  torch=="2.5.0.${NIGHTLY_VERSION}"
+  torch=="2.5.0.${PYTORCH_NIGHTLY_VERSION}"
+  torchvision=="0.20.0.${VISION_NIGHTLY_VERSION}"
 )
 
-# Install the requirements. `--extra-index-url` tells pip to look for package
+LINUX_REQUIREMENTS_TO_INSTALL=(
+  torchao=="0.5.0.${AO_NIGHTLY_VERSION}"
+  torchtune=="0.3.0.${TUNE_NIGHTLY_VERSION}"
+)
+
+# Install the requirements. --extra-index-url tells pip to look for package
 # versions on the provided URL if they aren't available on the default URL.
 (
   set -x
@@ -78,12 +94,15 @@ REQUIREMENTS_TO_INSTALL=(
     "${REQUIREMENTS_TO_INSTALL[@]}"
 )
 
-# For torchao need to install from github since nightly build doesn't have macos build.
-# TODO: Remove this and install nightly build, once it supports macos
-(
-  set -x
-  $PIP_EXECUTABLE install git+https://github.com/pytorch/ao.git@e11201a62669f582d81cdb33e031a07fb8dfc4f3
-)
+PLATFORM=$(uname -s)
+if [ "$PLATFORM" == "Linux" ]; then
+  (
+    set -x
+    $PIP_EXECUTABLE install --pre --extra-index-url "${TORCH_NIGHTLY_URL}" --no-cache-dir \
+      "${LINUX_REQUIREMENTS_TO_INSTALL[@]}"
+  )
+fi
+
 if [[ -x "$(command -v nvidia-smi)" ]]; then
   (
     set -x

--- a/install/install_requirements.sh
+++ b/install/install_requirements.sh
@@ -52,9 +52,6 @@ PYTORCH_NIGHTLY_VERSION=dev20240814
 # Nightly version for torchvision
 VISION_NIGHTLY_VERSION=dev20240814
 
-# Nightly version for torchao
-AO_NIGHTLY_VERSION=dev20240905
-
 # Nightly version for torchtune
 TUNE_NIGHTLY_VERSION=dev20240910
 
@@ -79,10 +76,6 @@ fi
 REQUIREMENTS_TO_INSTALL=(
   torch=="2.5.0.${PYTORCH_NIGHTLY_VERSION}"
   torchvision=="0.20.0.${VISION_NIGHTLY_VERSION}"
-)
-
-LINUX_REQUIREMENTS_TO_INSTALL=(
-  torchao=="0.5.0.${AO_NIGHTLY_VERSION}"
   torchtune=="0.3.0.${TUNE_NIGHTLY_VERSION}"
 )
 
@@ -94,27 +87,9 @@ LINUX_REQUIREMENTS_TO_INSTALL=(
     "${REQUIREMENTS_TO_INSTALL[@]}"
 )
 
-PLATFORM=$(uname -s)
-
-# Install torchtune and torchao requirements for Linux systems using nightly.
-# For non-Linux systems (e.g., macOS), install torchao from GitHub since nightly
-# build doesn't have macOS build.
-# TODO: Remove this and install nightly build, once it supports macOS
-if [ "$PLATFORM" == "Linux" ];
-then
-  (
-    set -x
-    $PIP_EXECUTABLE install --pre --extra-index-url "${TORCH_NIGHTLY_URL}" --no-cache-dir \
-      "${LINUX_REQUIREMENTS_TO_INSTALL[@]}"
-  )
-else
-  # For torchao need to install from github since nightly build doesn't have macos build.
-  # TODO: Remove this and install nightly build, once it supports macos
-  (
-    set -x
-    $PIP_EXECUTABLE install git+https://github.com/pytorch/ao.git@e11201a62669f582d81cdb33e031a07fb8dfc4f3
-  )
-fi
+(
+  set -x $PIP_EXECUTABLE install torchao=="0.5.0"
+)
 
 if [[ -x "$(command -v nvidia-smi)" ]]; then
   (

--- a/torchchat/cli/builder.py
+++ b/torchchat/cli/builder.py
@@ -35,11 +35,8 @@ from torchchat.utils.build_utils import (
 from torchchat.utils.measure_time import measure_time
 from torchchat.utils.quantize import quantize_model
 
-# bypass the import issue before torchao is ready on macos
-try:
-    from torchtune.models.convert_weights import meta_to_tune
-except:
-    pass
+from torchtune.models.convert_weights import meta_to_tune
+
 
 
 

--- a/torchchat/model.py
+++ b/torchchat/model.py
@@ -29,14 +29,9 @@ from torch.nn import functional as F
 
 from torchchat.utils.build_utils import find_multiple, get_precision
 
-# bypass the import issue, if any
-# TODO: remove this once the torchao is ready on macos
-try:
-    from torchtune.models.flamingo import flamingo_decoder, flamingo_vision_encoder
-    from torchtune.modules.model_fusion import DeepFusionModel 
-    from torchtune.models.llama3_1._component_builders import llama3_1 as llama3_1_builder
-except:
-    pass
+from torchtune.models.flamingo import flamingo_decoder, flamingo_vision_encoder
+from torchtune.modules.model_fusion import DeepFusionModel 
+from torchtune.models.llama3_1._component_builders import llama3_1 as llama3_1_builder
 
 config_path = Path(f"{str(Path(__file__).parent)}/model_params")
 


### PR DESCRIPTION
As torchao 0.5.0 released with mac prebuilt, we update installation script to enable torchtune across different platform