### PR TITLE
Update Chat Max_seq_len to 1024

### DIFF
--- a/torchchat/model.py
+++ b/torchchat/model.py
@@ -260,7 +260,7 @@ class TransformerArgs:
     multiple_of: int = 256
     ffn_dim_multiplier: Optional[int] = None
     use_tiktoken: bool = False
-    max_seq_length: int = 8192
+    max_seq_length: int = 1024
     rope_scaling: Optional[Dict[str, Any]] = None
     # For pipeline parallel
     n_stages: int = 1


### PR DESCRIPTION
As the max_seq_len increases, the tps starts to degrade on certain computers. 

For a basic CLI example 1024 is sufficient for now