### PR TITLE
Converting transformer_args to explicit object for checkpoint construction

### DIFF
--- a/torchchat/cli/convert_hf_checkpoint.py
+++ b/torchchat/cli/convert_hf_checkpoint.py
@@ -33,7 +33,7 @@ def convert_hf_checkpoint(
         model_name = model_dir.name
 
     config = ModelArgs.from_name(model_name).transformer_args['text']
-    print(f"Model config {config.__dict__}")
+    print(f"Model config {config}")
 
     # Load the json file containing weight mapping
     model_map_json = model_dir / "pytorch_model.bin.index.json"

--- a/torchchat/cli/convert_hf_checkpoint.py
+++ b/torchchat/cli/convert_hf_checkpoint.py
@@ -12,6 +12,8 @@ from typing import Optional
 
 import torch
 
+from torchchat.model import TransformerArgs
+
 # support running without installing as a package
 wd = Path(__file__).parent.parent
 sys.path.append(str(wd.resolve()))
@@ -32,8 +34,9 @@ def convert_hf_checkpoint(
     if model_name is None:
         model_name = model_dir.name
 
-    config = ModelArgs.from_name(model_name).transformer_args['text']
-    print(f"Model config {config}")
+    config_args = ModelArgs.from_name(model_name).transformer_args['text']
+    config = TransformerArgs.from_params(config_args)
+    print(f"Model config {config.__dict__}")
 
     # Load the json file containing weight mapping
     model_map_json = model_dir / "pytorch_model.bin.index.json"


### PR DESCRIPTION
Side effect of https://github.com/pytorch/torchchat/commit/964d43713bd993fc81cec71a6043b22550580692 was that ModelArgs was updated to the following
```
    ModelArgs.transformer_args: Dict[str, Dict[str, Any]]
```

The checkpoint translation requires the field from TransformerArgs, so this creates an explicit object from the config