### PR TITLE
Unsupress params and tokenizer path in CLI

### DIFF
--- a/torchchat/cli/cli.py
+++ b/torchchat/cli/cli.py
@@ -86,7 +86,6 @@ def add_arguments_for_verb(parser, verb: str) -> None:
 
     # WIP Features (suppressed from --help)
     _add_distributed_args(parser)
-    _add_custom_model_args(parser)
     _add_speculative_execution_args(parser)
 
 
@@ -94,7 +93,7 @@ def add_arguments_for_verb(parser, verb: str) -> None:
 def _add_model_specification_args(parser) -> None:
     model_specification_parser = parser.add_argument_group(
         "Model Specification",
-        "(REQUIRED) Specify the base model. Args are mutually exclusive.",
+        "A base model is required: `model` XOR `checkpoint-path`",
     )
     exclusive_parser = model_specification_parser.add_mutually_exclusive_group(
         required=True
@@ -112,7 +111,8 @@ def _add_model_specification_args(parser) -> None:
         default="not_specified",
         help="Use the specified model checkpoint path",
     )
-    # See _add_custom_model_args() for more details
+
+    _add_custom_model_args(model_specification_parser)
     exclusive_parser.add_argument(
         "--gguf-path",
         type=Path,
@@ -411,8 +411,7 @@ def _add_distributed_args(parser) -> None:
     )
 
 
-# Add CLI Args related to custom model inputs (e.g. GGUF)
-# This feature is currently a [WIP] and hidden from --help
+# Add CLI Args related to custom model inputs
 def _add_custom_model_args(parser) -> None:
     parser.add_argument(
         "--params-table",
@@ -426,15 +425,13 @@ def _add_custom_model_args(parser) -> None:
         "--params-path",
         type=Path,
         default=None,
-        help=argparse.SUPPRESS,
-        # "Use the specified parameter file",
+        help= "Use the specified parameter file, instead of one specified under torchchat.model_params",
     )
     parser.add_argument(
         "--tokenizer-path",
         type=Path,
         default=None,
-        help=argparse.SUPPRESS,
-        # "Use the specified model tokenizer file",
+        help= "Use the specified model tokenizer file, instead of the one downloaded from HuggingFace",
     )
 
 


### PR DESCRIPTION
These are fields that were already supported in torchchat, but were simply suppressed in the help menu.

This just unsurpassed them

> python3 torchchat.py generate --help


``` 
usage: torchchat generate [-h] [--checkpoint-path CHECKPOINT_PATH] [--params-path PARAMS_PATH]
                          [--tokenizer-path TOKENIZER_PATH] [--compile] [--compile-prefill]
                          [--dtype {fp32,fp16,bf16,float,half,float32,float16,bfloat16,fast,fast16}] [--quantize QUANTIZE]
                          [--device {fast,cpu,cuda,mps}] [--dso-path DSO_PATH | --pte-path PTE_PATH] [--prompt PROMPT]
                          [--num-samples NUM_SAMPLES] [--image-prompts IMAGE_PROMPTS [IMAGE_PROMPTS ...]]
                          [--max-new-tokens MAX_NEW_TOKENS] [--top-k TOP_K] [--temperature TEMPERATURE] [--max-autotune]
                          [--hf-token HF_TOKEN] [--model-directory MODEL_DIRECTORY] [-v] [--seed SEED]
                          [model]

options:
  -h, --help            show this help message and exit
  -v, --verbose         Verbose output
  --seed SEED           Initialize torch seed

Model Specification:
  A base model is required: `model` XOR `checkpoint-path`

  model                 Model name for well-known models
  --checkpoint-path CHECKPOINT_PATH
                        Use the specified model checkpoint path
  --params-path PARAMS_PATH
                        Use the specified parameter file, instead of one specified under torchchat.model_params
  --tokenizer-path TOKENIZER_PATH
                        Use the specified model tokenizer file, instead of the one downloaded from HuggingFace

...
```