### PR TITLE
remove model.model in ckpt loading

### DIFF
--- a/install/install_requirements.sh
+++ b/install/install_requirements.sh
@@ -53,7 +53,7 @@ PYTORCH_NIGHTLY_VERSION=dev20240814
 VISION_NIGHTLY_VERSION=dev20240814
 
 # Nightly version for torchtune
-TUNE_NIGHTLY_VERSION=dev20240916
+TUNE_NIGHTLY_VERSION=dev20240918
 
 
 # Uninstall triton, as nightly will depend on pytorch-triton, which is one and the same

--- a/install/install_requirements.sh
+++ b/install/install_requirements.sh
@@ -53,7 +53,7 @@ PYTORCH_NIGHTLY_VERSION=dev20240814
 VISION_NIGHTLY_VERSION=dev20240814
 
 # Nightly version for torchtune
-TUNE_NIGHTLY_VERSION=dev20240918
+TUNE_NIGHTLY_VERSION=dev20240916
 
 
 # Uninstall triton, as nightly will depend on pytorch-triton, which is one and the same

--- a/torchchat/cli/builder.py
+++ b/torchchat/cli/builder.py
@@ -388,11 +388,9 @@ def _load_model_default(builder_args, only_config=False):
             builder_args.device
         ):
             model = Model.from_params(builder_args.params_path)
-        state_dict = flamingo_meta_to_tune(checkpoint)
-        model.model.load_state_dict(state_dict)
-    else:
-        checkpoint = {"model." + k: v for k, v in checkpoint.items()}
-        model.load_state_dict(checkpoint, assign=True, strict=True)
+        checkpoint = flamingo_meta_to_tune(checkpoint)
+
+    model.load_state_dict(checkpoint, assign=True, strict=True)
 
     return model
 

--- a/torchchat/model.py
+++ b/torchchat/model.py
@@ -442,6 +442,8 @@ class Model(ABC, nn.Module):
         # It should be assigned in the actual model implementation, if any.
         self.text_transformer_args = None
 
+        self._register_load_state_dict_pre_hook(self._load_model_state_dict)
+
     def build_model(self) -> nn.Module:
         """
         Builds a model based on the provided configuration.
@@ -467,6 +469,13 @@ class Model(ABC, nn.Module):
             if isinstance(value, Hashable) and value in patterns:
                 params[key] = patterns[value]
         return params
+    
+    def _load_model_state_dict(self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs):
+        # 修改 state dict 中的键值
+        for key in list(state_dict.keys()):
+            new_key = 'model.' + key
+            state_dict[new_key] = state_dict.pop(key)
+        return state_dict
     
     @abstractmethod
     def forward(self, *args, **kwargs):

--- a/torchchat/model.py
+++ b/torchchat/model.py
@@ -480,7 +480,20 @@ class Model(ABC, nn.Module):
         unexpected_keys,
         error_msgs,
     ):
-        # update key names to match the new model
+        """
+        Updates the loaded internal model state dictionary to match the Model class structure.
+        Note that this is a temporary solution and will be removed once the model structure is finalized.
+        Args:
+            state_dict (dict): The state dictionary to load.
+            prefix (str): The prefix of the model.
+            local_metadata (dict): Local metadata.
+            strict (bool): Whether to strictly enforce that the keys in the state dictionary match the keys in the model.
+            missing_keys (list): List of missing keys.
+            unexpected_keys (list): List of unexpected keys.
+            error_msgs (list): List of error messages.
+        Returns:
+            dict: The updated state dictionary.            
+        """
         for key in list(state_dict.keys()):
             new_key = "model." + key
             state_dict[new_key] = state_dict.pop(key)

--- a/torchchat/model.py
+++ b/torchchat/model.py
@@ -495,7 +495,8 @@ class Model(ABC, nn.Module):
         :return: The attribute value if found, otherwise raise AttributeError.
         """
         try:
-            return super().__getattribute__(name)
+            if name in self.__dict__:
+                return self.__dict__[name]
         except AttributeError:
             pass
 

--- a/torchchat/model.py
+++ b/torchchat/model.py
@@ -486,27 +486,6 @@ class Model(ABC, nn.Module):
             state_dict[new_key] = state_dict.pop(key)
         return state_dict
 
-    def __getattr__(self, name):
-        """
-        Rewrite __getattr__ to search attribute in Model and its model attribute.
-        Note that this is a temporary solution to expose internal model attributes to the user.
-
-        :param name: The name of the attribute to get.
-        :return: The attribute value if found, otherwise raise AttributeError.
-        """
-        try:
-            if name in self.__dict__:
-                return self.__dict__[name]
-        except AttributeError:
-            pass
-
-        try:
-            return getattr(self.model, name)
-        except AttributeError:
-            raise AttributeError(
-                f"'{type(self).__name__}' object has no attribute '{name}'"
-            )
-            
     @abstractmethod
     def forward(self, *args, **kwargs):
         raise NotImplementedError("forward method is not implemented")

--- a/torchchat/utils/gguf_loader.py
+++ b/torchchat/utils/gguf_loader.py
@@ -47,7 +47,6 @@ def _convert_gguf_tensor_name_to_llama_nn(gguf_name: str) -> str:
     result = copy.deepcopy(gguf_name)
     for gguf_string, replacement in _name_replacements:
         result = result.replace(gguf_string, replacement)
-    result = "model." + result
     return result
 
 

--- a/torchchat/utils/gguf_loader.py
+++ b/torchchat/utils/gguf_loader.py
@@ -54,6 +54,10 @@ def _fqn_lookup(fqn: str, module: torch.nn.Module) -> Any:
     if fqn == "":
         return module
     atoms = fqn.split(".")
+    # Expose the root module to users.
+    # Note this is temporary, and will be removed once we removed Model.model
+    if isinstance(module, Model):
+        module = module.model
     curr = module
     for a in atoms:
         curr = getattr(curr, a)


### PR DESCRIPTION
This PR introduced a hook for model checkpoint remapping to remove model.model when model loading for better clearance.