### PR TITLE
Fix support for ET repo generated pte by optionally adding batch dim

### DIFF
--- a/torchchat/model.py
+++ b/torchchat/model.py
@@ -951,6 +951,11 @@ try:
             # the first element to get the tensor
             assert len(logits) == 1
             logits = logits[0]
+
+            # Add a batch dimension, if it's missing (e.g. some pte's
+            # exported from the ExecuTorch repo)
+            if logits.dim() == 2:
+                logits = logits.unsqueeze(0)
             return logits
 
         def setup_caches(self, max_batch_size, max_seq_length):


### PR DESCRIPTION
As titled, torchchat expects logits as (1, 1, vocab size), but depending on the exporting logic the batch dim is not provided (for example with pte generated from the ET repo

This just adds a simple check and layer if needed.

Tested by 

```
python3 torchchat.py generate llama3.1 --pte-path <pte from ET repo export>
python3 torchchat.py generate llama3.1 --pte-path <pte from TC repo export>
```
