### PR TITLE
Use default max_seq_length of 128 when loading ExecuTorch models

### DIFF
--- a/torchchat/generate.py
+++ b/torchchat/generate.py
@@ -818,6 +818,7 @@ class Generator:
                     if text_transformer_args is not None
                     else 2048
                 ),
+                max_seq_length
             )
 
         max_seq_length = (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

We just defaulted on export, we should also default on load. ExecuTorch has API to get the max seq length, but the Python API currently segfaults when the method is missing.