### PR TITLE
Also use default max_seq_length of 128 for ExecuTorch native runner

### DIFF
--- a/runner/run.cpp
+++ b/runner/run.cpp
@@ -835,7 +835,7 @@ int main(int argc, char* argv[]) {
   float topp = 0.9f; // top-p in nucleus sampling. 1.0 = off. 0.9 works well,
                      // but slower
 
-  int steps = 256; // number of steps to run for
+  int steps = 128; // number of steps to run for
   const char* prompt = NULL; // prompt string
   unsigned long long rng_seed = 0; // seed rng with time by default
   const char* mode = "generate"; // generate|chat


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1171
* #1170
* __->__ #1186
* #1184
* #1169
* #1168
* #1181

