### PR TITLE
Revert "export.py: fix custom SDPA type conversion logic & re-enable for bfloat16"

### DIFF
--- a/torchchat/export.py
+++ b/torchchat/export.py
@@ -199,7 +199,7 @@ try:
                 input_pos[-1].item(),
                 seqlen,
             )
-            output = output.view(bsz, seqlen, self.dim).to(dtype=x.dtype)
+            output = output.view(bsz, seqlen, self.dim).to(dtype=q.dtype)
             return self.wo(output)
 
     def replace_attention_with_custom_sdpa_attention(module: nn.Module):
@@ -291,7 +291,11 @@ try:
             model = model.to(dtype=target_precision)
             state_dict_dtype = target_precision
 
-        replace_attention_with_custom_sdpa_attention(model)
+        # Custom SDPA does not work with bfloat16 on CPU currently. (The op doesn't
+        # support anything but bfloat32, and our attempt to use it anyway by converting
+        # to and from float causes other errors.)
+        if target_precision != torch.bfloat16:
+            replace_attention_with_custom_sdpa_attention(model)
 
         with torch.nn.attention.sdpa_kernel(
             [torch.nn.attention.SDPBackend.MATH]


### PR DESCRIPTION
Reverts pytorch/torchchat#1193 -- trunk runner-et job https://github.com/pytorch/torchchat/actions/runs/11022084837/job/30610612304 is showing garbage output for fp16 and bf16, previous job had normal output. I suspect that #1193 fixes a real bug that was covering up a different bug, though; will investigate.