### PR TITLE
Make default max_seq_length in openai_api consistent to chat

### DIFF
--- a/torchchat/usages/openai_api.py
+++ b/torchchat/usages/openai_api.py
@@ -289,7 +289,7 @@ class OpenAiApiGenerator(Generator):
             )
         except:
             # can not find max_seq_length in model config, use default value
-            self.max_seq_length = 128
+            self.max_seq_length = 2048
         # The System fingerprint is a unique identifier for the model and its configuration.
         self.system_fingerprint = (
             f"{self.builder_args.device}_{self.builder_args.precision}"


### PR DESCRIPTION
Those two apis should have the same default max_seq_length. There can be a better location to define this. The max_seq_length in chat is 2048, in https://github.com/pytorch/torchchat/blob/main/torchchat/generate.py#L821.

The way max_seq_length defined in model looks flaky. It should be consistent to the model definition and the cache setup.