### PR TITLE
Update install_et.sh to install numpy 1.21.3

### DIFF
--- a/torchchat/utils/scripts/install_et.sh
+++ b/torchchat/utils/scripts/install_et.sh
@@ -24,5 +24,5 @@ install_executorch_python_libs $ENABLE_ET_PYBIND
 # has no attribute 'utils'' error from evaluate CI jobs and remove
 # `import lm_eval` from torchchat.py since it requires a specific version
 # of numpy.
-pip install numpy=='1.26.4'
+pip install numpy=='1.21.3'
 popd


### PR DESCRIPTION
ET requires a specific version of ET

```
pipdeptree -r --packages numpy
Warning!!! Duplicate package metadata found:
"/home/jackkhuu/.conda/envs/newnew/lib/python3.10/site-packages"
  fsspec                           2024.6.1         (using 2024.9.0, "/home/jackkhuu/.conda/envs/newnew/lib/python3.10/site-packages")
NOTE: This warning isn't a failure warning.
------------------------------------------------------------------------
Warning!!! Possibly conflicting dependencies found:
* datasets==3.0.1
 - fsspec [required: >=2023.1.0,<=2024.6.1, installed: 2024.9.0]
* executorch==0.5.0a0+286799c
 - numpy [required: ==1.21.3, installed: 1.26.4]
------------------------------------------------------------------------
numpy==1.26.4
├── accelerate==0.34.2 [requires: numpy>=1.17,<3.0.0]
│   ├── lm_eval==0.4.2 [requires: accelerate>=0.21.0]
│   └── peft==0.13.0 [requires: accelerate>=0.21.0]
│       └── lm_eval==0.4.2 [requires: peft>=0.2.0]
├── datasets==3.0.1 [requires: numpy>=1.17]
│   ├── evaluate==0.4.3 [requires: datasets>=2.0.0]
│   │   ├── lm_eval==0.4.2 [requires: evaluate]
│   │   └── lm_eval==0.4.2 [requires: evaluate>=0.4.0]
│   ├── lm_eval==0.4.2 [requires: datasets>=2.16.0]
│   └── torchtune==0.0.0 [requires: datasets]
├── evaluate==0.4.3 [requires: numpy>=1.17]
│   ├── lm_eval==0.4.2 [requires: evaluate]
│   └── lm_eval==0.4.2 [requires: evaluate>=0.4.0]
├── executorch==0.5.0a0+286799c [requires: numpy==1.21.3]
```