### PR TITLE
Raise a8wxdq load errors only when quant scheme is used

### DIFF
--- a/torchchat/utils/quantize.py
+++ b/torchchat/utils/quantize.py
@@ -51,6 +51,9 @@ from torchchat.utils.build_utils import (
 )
 
 
+# Flag for whether the a8wxdq quantizer is available.
+a8wxdq_loaded = False
+
 #########################################################################
 ###                  torchchat quantization API                       ###
 
@@ -97,6 +100,9 @@ def quantize_model(
 
             try:
                 if quantizer == "linear:a8wxdq":
+                    if not a8wxdq_loaded:
+                        raise Exception(f"Note: Failed to load torchao experimental a8wxdq quantizer with error: {e}")
+
                     quant_handler = ao_quantizer_class_dict[quantizer](
                         device=device,
                         precision=precision,
@@ -898,5 +904,8 @@ try:
         print("Failed to torchao ops library with error: ", e)
         print("Slow fallback kernels will be used.")
 
+    # Mark the Quant option as available
+    a8wxdq_loaded = True
+
 except Exception as e:
-    print(f"Failed to load torchao experimental a8wxdq quantizer with error: {e}")
+    pass


### PR DESCRIPTION
As titled, originally the message was shown regardless of whether the scheme was used; tested on Mac (ARM)

---
Not Using Quant
```
> python3 torchchat.py generate llama3.1 --device cpu
Using device=cpu Apple M1 Max
Loading model...
Time to load model: 2.24 seconds
-----------------------------------------------------------
```
---
Using Quant 
```
> OMP_NUM_THREADS=6 python3 torchchat.py generate llama3.1 --device cpu --dtype float32 --quantize '{"linear:a8wxdq": {"bitwidth": 4, "groupsize": 256, "has_weight_zeros": false}}'
```

w/o Loading
```
Using device=cpu Apple M1 Max
Loading model...
Time to load model: 2.74 seconds
Quantizing the model with: {'linear:a8wxdq': {'bitwidth': 4, 'groupsize': 256, 'has_weight_zeros': False}}
Time to quantize model: 0.00 seconds
Traceback (most recent call last):
  File "/Users/jackkhuu/Desktop/oss/torchchat/torchchat.py", line 83, in <module>
    generate_main(args)
  File "/Users/jackkhuu/Desktop/oss/torchchat/torchchat/generate.py", line 1093, in main
    gen = Generator(
          ^^^^^^^^^^
  File "/Users/jackkhuu/Desktop/oss/torchchat/torchchat/generate.py", line 284, in __init__
    self.model = _initialize_model(self.builder_args, self.quantize, self.tokenizer)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jackkhuu/Desktop/oss/torchchat/torchchat/cli/builder.py", line 568, in _initialize_model
    quantize_model(
  File "/Users/jackkhuu/Desktop/oss/torchchat/torchchat/utils/quantize.py", line 84, in quantize_model
    raise Exception(f"Note: Failed to load torchao experimental a8wxdq quantizer with error: {a8wxdq_load_error}")
Exception: Note: Failed to load torchao experimental a8wxdq quantizer with error: [Errno 2] No such file or directory: '/Users/jackkhuu/Desktop/oss/torchchat/torchao-build/src/ao/torchao/experimental/quant_api.py'
```

w/ Loading
```
Using device=cpu Apple M1 Max
Loading model...
Time to load model: 2.98 seconds
Quantizing the model with: {'linear:a8wxdq': {'bitwidth': 4, 'groupsize': 256, 'has_weight_zeros': False}}
```