### PR TITLE
Only show MPS Compile Warning if compile is attempted

### DIFF
--- a/torchchat/cli/cli.py
+++ b/torchchat/cli/cli.py
@@ -494,7 +494,7 @@ def arg_init(args):
         )
 
     if "mps" in args.device:
-        if hasattr(args, "compile") and hasattr(args, "compile_prefill"):
+        if getattr(args, "compile", False) or getattr(args, "compile_prefill", False):
             print(
                 "Warning: compilation is not available with device MPS, ignoring option to engage compilation"
             )


### PR DESCRIPTION
No Compile, No Warning
```
python torchchat.py generate llama3.1
Using device=mps
Loading model...
Time to load model: 10.68 seconds
-----------------------------------------------------------
```

With compile, with Warning
```
python torchchat.py generate llama3.1 --compile
Warning: compilation is not available with device MPS, ignoring option to engage compilation
Using device=mps
Loading model...
Time to load model: 11.98 seconds
-----------------------------------------------------------
```