### PR TITLE
Move .lintrunner.toml to top-level directory and include basic linting instructions in CONTRIBUTING.md

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -19,7 +19,7 @@ init_command = [
     'run',
     'pip_init',
     '--dry-run={{DRYRUN}}',
-    '--requirement=requirements-lintrunner.txt',
+    '--requirement=install/requirements-lintrunner.txt',
 ]
 
 # Black + usort
@@ -46,7 +46,7 @@ init_command = [
     'pip_init',
     '--dry-run={{DRYRUN}}',
     '--no-black-binary',
-    '--requirement=requirements-lintrunner.txt',
+    '--requirement=install/requirements-lintrunner.txt',
 ]
 is_formatter = true
 
@@ -75,6 +75,6 @@ init_command = [
     'run',
     'pip_init',
     '--dry-run={{DRYRUN}}',
-    '--requirement=requirements-lintrunner.txt',
+    '--requirement=install/requirements-lintrunner.txt',
 ]
 is_formatter = true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,22 @@ We actively welcome your pull requests.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
 4. Ensure the test suite passes.
-5. Make sure your code lints.
+5. Make sure your code is well-formatted using the repo linter. See "Linting" for details.
 6. If you haven't already, complete the Contributor License Agreement ("CLA").
+
+
+### Linting
+Install the lintrunner dependencies from the requirements file.
+```
+pip3 install -r install/requirements-lintrunner.txt
+```
+
+After making your changes locally, run the lintrunner and apply all suggestions to your changes.
+You can do this from the top-level torchchat directory - it will apply suggestions only to files that
+you have touched.
+```
+lintrunner -a
+```
 
 ## Contributor License Agreement ("CLA")
 In order to accept your pull request, we need you to submit a CLA. You only need


### PR DESCRIPTION
Lintrunner is currently broken since the .lintrunner.toml was moved to the install directory. 

This PR updates the necessary paths & moves .lintrunner.toml back to the top-level directory so that lint changes can be applied. 

I also provide basic instructions on linter installation & usage in the CONTRIBUTING.md.

Tested using a fresh venv as follows:

```
python3 -m venv .venv                            
source .venv/bin/activate
./install/install_requirements.sh

pip3 install -r install/requirements-lintrunner.txt
```

```
(.venv) puri@puri-mac torchchat % lintrunner -a
Warning: Could not find a lintrunner config at: '.lintrunner.private.toml'. Continuing without using configuration file.
ok No lint issues.
Successfully applied all patches.
```