### PR TITLE
Tokenizers tokenizer

### DIFF
--- a/tokenizer/base.py
+++ b/tokenizer/base.py
@@ -1,0 +1,32 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+Abstract base class for all tokenizer classes in python matching c++ interface.
+"""
+
+# Standard
+from abc import ABC, abstractmethod
+from typing import List
+
+
+class TokenizerBase(ABC):
+    __doc__ = __doc__
+
+    @abstractmethod
+    def encode(self, s: str, *, bos: bool = False, eos: bool = False) -> List[int]:
+        """Encode the given string and optionally include bos/eos tokens"""
+
+    @abstractmethod
+    def decode(self, ids: List[int]) -> str:
+        """Decode the given token ids into a string"""
+
+    @abstractmethod
+    def bos_id(self) -> int:
+        """The id of the begin-of-string token"""
+
+    @abstractmethod
+    def eos_id(self) -> int:
+        """The id of the end-of-string token"""

--- a/tokenizer/hf_tokenizer.py
+++ b/tokenizer/hf_tokenizer.py
@@ -16,9 +16,9 @@ from tokenizers import Tokenizer
 from .base import TokenizerBase
 
 
-class TokenizersTokenizer(TokenizerBase):
+class HFTokenizer(TokenizerBase):
     """
-    Wrapper around the `tokenizers` library for API compatibility
+    Wrapper around the Huggingface `tokenizers` library for API compatibility
     """
 
     def __init__(self, file_path: str):

--- a/tokenizer/tiktoken.py
+++ b/tokenizer/tiktoken.py
@@ -23,6 +23,8 @@ from typing import (
 import tiktoken
 from tiktoken.load import load_tiktoken_bpe
 
+from .base import TokenizerBase
+
 
 logger = getLogger(__name__)
 
@@ -38,7 +40,7 @@ class Message(TypedDict):
 Dialog = Sequence[Message]
 
 
-class Tokenizer:
+class Tokenizer(TokenizerBase):
     """
     tokenizing and encoding/decoding text using the Tiktoken tokenizer.
     """

--- a/tokenizer/tokenizers.py
+++ b/tokenizer/tokenizers.py
@@ -1,0 +1,64 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Standard
+from typing import List
+import json
+
+# Third Party
+from tokenizers import Tokenizer
+
+# Local
+from .base import TokenizerBase
+
+
+class TokenizersTokenizer(TokenizerBase):
+    """
+    Wrapper around the `tokenizers` library for API compatibility
+    """
+
+    def __init__(self, file_path: str):
+        self._tokenizer = Tokenizer.from_file(file_path)
+        # The BOS and EOS tokens are not easily visible from the tokenizer
+        # object itself, so we extract them at construction with a sample call
+        self._bos_token = self._tokenizer.encode("Test", add_special_tokens=True).ids[0]
+        # There is no explicit BOS token in many tokenizers, so we look for a
+        # single special token that most resembles the BOS token.
+        self._eos_token = None
+        tok_content = json.loads(self._tokenizer.to_str())
+        end_toks = [
+            tok for tok in tok_content['added_tokens']
+            if tok["special"] and "end" in tok["content"]
+        ]
+        assert end_toks, "Unable to find an EOS token in the added tokens"
+        if len(end_toks) > 1:
+            end_text_toks = [
+                tok for tok in end_toks if "text" in tok["content"]
+            ]
+            if len(end_text_toks) == 1:
+                self._eos_token = end_text_toks[0]["id"]
+        assert self._eos_token is not None, "Unable to find an EOS token in the added tokens"
+
+    def encode(
+        self,
+        s: str,
+        *,
+        bos: bool = False,
+        eos: bool = False,
+    ) -> List[int]:
+        res = self._tokenizer.encode(s, add_special_tokens=bos).ids
+        if eos and (not res or res[-1] != self._eos_token):
+            res.append(self._eos_token)
+        return res
+
+    def decode(self, ids: List[int]) -> str:
+        return self._tokenizer.decode(ids)
+
+    def bos_id(self) -> int:
+        return self._bos_token
+
+    def eos_id(self) -> int:
+        return self._eos_token

--- a/torchchat/cli/builder.py
+++ b/torchchat/cli/builder.py
@@ -204,6 +204,7 @@ class TokenizerArgs:
     tokenizer_path: Optional[Union[Path, str]] = None
     is_sentencepiece: bool = False
     is_tiktoken: bool = False
+    is_tokenizers: bool = False
     t: Optional[Any] = None
 
     def __post_init__(self):
@@ -213,6 +214,7 @@ class TokenizerArgs:
             self.t = TiktokenTokenizer(model_path=str(self.tokenizer_path))
             self.is_tiktoken = True
             self.is_sentencepiece = False
+            self.is_tokenizers = False
             return
         except:
             pass
@@ -223,12 +225,25 @@ class TokenizerArgs:
             self.t = SentencePieceProcessor(model_file=str(self.tokenizer_path))
             self.is_tiktoken = False
             self.is_sentencepiece = True
+            self.is_tokenizers = False
+            return
+        except:
+            pass
+
+        try:
+            from tokenizer.tokenizers import TokenizersTokenizer
+
+            self.t = TokenizersTokenizer(str(self.tokenizer_path))
+            self.is_tiktoken = False
+            self.is_sentencepiece = False
+            self.is_tokenizers = True
             return
         except:
             pass
 
         self.is_tiktoken = False
         self.is_sentencepiece = False
+        self.is_tokenizers = False
         self.t = None
         return
 
@@ -240,16 +255,27 @@ class TokenizerArgs:
         if model is None:
             return
 
-        if self.is_tiktoken == self.is_sentencepiece:
+        if len(list(filter(lambda x: x, [self.is_tiktoken, self.is_tokenizers, self.is_sentencepiece]))) != 1:
             raise RuntimeError(f"no tokenizer was found at {self.tokenizer_path}")
 
         is_tiktoken = self.is_tiktoken
         is_sentencepiece = self.is_sentencepiece
+        is_tokenizers = self.is_tokenizers
         use_tiktoken = model.config.use_tiktoken
+        use_tokenizers = model.config.use_tokenizers
+        use_sentencepiece = not (use_tiktoken or use_tokenizers)
 
-        if not (is_tiktoken == use_tiktoken) or not (is_sentencepiece != use_tiktoken):
+        if (
+            (is_tiktoken and not use_tiktoken) or
+            (is_tokenizers and not use_tokenizers) or
+            (is_sentencepiece and not use_sentencepiece)
+        ):
             raise RuntimeError(
-                f"model-specified tokenizer ({tokenizer_setting_to_name(use_tiktoken)}) does not match provided tokenizer ({tokenizer_setting_to_name(is_tiktoken)}) for {model_description}"
+                "model-specified tokenizer ({}) does not match provided tokenizer ({}) for {}".format(
+                    tokenizer_setting_to_name(use_tiktoken, use_tokenizers),
+                    tokenizer_setting_to_name(is_tiktoken, is_tokenizers),
+                    model_description,
+                )
             )
 
         return
@@ -605,5 +631,9 @@ def _initialize_model(
     return model
 
 
-def tokenizer_setting_to_name(tiktoken: bool = False) -> str:
-    return "TikToken" if tiktoken else "SentencePiece"
+def tokenizer_setting_to_name(tiktoken: bool, tokenizers: bool) -> str:
+    if tiktoken:
+        return "TikToken"
+    if tokenizers:
+        return "Tokenizers"
+    return "SentencePiece"

--- a/torchchat/model.py
+++ b/torchchat/model.py
@@ -270,7 +270,9 @@ class TransformerArgs:
     norm_eps: float = 1e-5
     multiple_of: int = 256
     ffn_dim_multiplier: Optional[int] = None
+    # Select the desired tokenizer. Defaults to sentencepiece
     use_tiktoken: bool = False
+    use_tokenizers: bool = False
     max_seq_length: int = 8192
     rope_scaling: Optional[Dict[str, Any]] = None
     # For pipeline parallel
@@ -327,12 +329,14 @@ class ModelArgs:
     model_type: ModelType
     transformer_args: Dict[str, Dict[str, Any]]
     use_tiktoken: bool
+    use_tokenizers: bool
 
     def __init__(
         self,
         transformer_args: Dict[str, Dict[str, Any]],
         model_type: ModelType = ModelType.TextOnly,
         use_tiktoken: bool = False,
+        use_tokenizers: bool = False,
     ) -> None:
         self._sanity_check(transformer_args, model_type)
 
@@ -341,6 +345,7 @@ class ModelArgs:
 
         # Model-level attributes
         self.use_tiktoken = use_tiktoken
+        self.use_tokenizers = use_tokenizers
 
     def _sanity_check(
         self,
@@ -367,7 +372,8 @@ class ModelArgs:
             }
 
         use_tiktoken = loaded_params.get("use_tiktoken", False)
-        return cls(transformer_args, model_type, use_tiktoken)
+        use_tokenizers = loaded_params.get("use_tokenizers", False)
+        return cls(transformer_args, model_type, use_tiktoken, use_tokenizers)
 
     @classmethod
     def from_table(cls, name: str):

--- a/torchchat/model.py
+++ b/torchchat/model.py
@@ -272,7 +272,7 @@ class TransformerArgs:
     ffn_dim_multiplier: Optional[int] = None
     # Select the desired tokenizer. Defaults to sentencepiece
     use_tiktoken: bool = False
-    use_tokenizers: bool = False
+    use_hf_tokenizer: bool = False
     max_seq_length: int = 8192
     rope_scaling: Optional[Dict[str, Any]] = None
     # For pipeline parallel
@@ -329,14 +329,14 @@ class ModelArgs:
     model_type: ModelType
     transformer_args: Dict[str, Dict[str, Any]]
     use_tiktoken: bool
-    use_tokenizers: bool
+    use_hf_tokenizer: bool
 
     def __init__(
         self,
         transformer_args: Dict[str, Dict[str, Any]],
         model_type: ModelType = ModelType.TextOnly,
         use_tiktoken: bool = False,
-        use_tokenizers: bool = False,
+        use_hf_tokenizer: bool = False,
     ) -> None:
         self._sanity_check(transformer_args, model_type)
 
@@ -345,7 +345,7 @@ class ModelArgs:
 
         # Model-level attributes
         self.use_tiktoken = use_tiktoken
-        self.use_tokenizers = use_tokenizers
+        self.use_hf_tokenizer = use_hf_tokenizer
 
     def _sanity_check(
         self,
@@ -372,8 +372,8 @@ class ModelArgs:
             }
 
         use_tiktoken = loaded_params.get("use_tiktoken", False)
-        use_tokenizers = loaded_params.get("use_tokenizers", False)
-        return cls(transformer_args, model_type, use_tiktoken, use_tokenizers)
+        use_hf_tokenizer = loaded_params.get("use_hf_tokenizer", False)
+        return cls(transformer_args, model_type, use_tiktoken, use_hf_tokenizer)
 
     @classmethod
     def from_table(cls, name: str):


### PR DESCRIPTION
## Dependencies

This PR is part of a sequence in support of adding Granite Code. It depends on merging the following PRs:

- [x] Safetensors: #1255
- [x] Bias tensors: #1259 
- [x] Tied word embeddings: #1260 

## Issues

Closes #1251 

## Description

This PR adds partial support for models that use the `tokenizers` (as opposed to `tiktoken` or `sentencepiece`) for tokenization. This PR only addresses support in the `python` runner, and it does so by creating a new class in the `tokenizer` module that simply wraps `tokenizers`.

## Discussion

I'm not sure this is the correct direction to go for solving this since the `tokenizers` library is not (to the best of my knowledge) portable to the various export formats (yet). There are two main challenges to extending more tokenizer support outside of simply wrapping `tokenizers`:

### Pre-tokenizers

For may tokenizers, multiple regexes are used in sequence to split the raw string. Not being a regex expert myself, it's not immediately clear to me if it's possible to merge this kind of multi-pass splitting into a single regex. For other tokenizers, a single regex is used, but it is a different expression than any of those [currently implemented in `tiktoken`](https://github.com/pytorch/torchchat/blob/main/tokenizer/tokenizer.h#L138).

From my investigation, I think there are a few candidate paths forward:

1. Provide a `c++` implementation of the various tokenization routines from `tokenizers` in a separate implementation of the [`Tokenizer` class](https://github.com/pytorch/torchchat/blob/main/tokenizer/tokenizer.h#L27).
2. Extend the existing `c++` [`TikToken` class](https://github.com/pytorch/torchchat/blob/main/tokenizer/tiktoken.cpp) to support multiple regexes in the pre-tokenizer
    * This would also correspond with needing to make the set of patterns configurable and therefore serialized into the `tokenizer.model` artifact, or somehow making these tokenizer arguments an argument at instantiation time.

**NOTE:** The corresponding tokenization in `llama.cpp` lives [here](https://github.com/ggerganov/llama.cpp/blob/master/src/llama-vocab.cpp). This code is a full implementation of a unified tokenizer with configuration to dispatch between known patterns and optimized implementations. The config for the model that indicates which tokenizer to use is stored in the model's `GGUF` file directly, so at load time, the correct tokenizer is found based on that value.

### Special Tokens

Even for models that use a single regex (and even the `llama` regex), models may use different special tokens for special functionality (chat template, FIM, tool calling, other custom prompting). Since the `tokenizer.model`, only the vocab is stored, so there is not currently any way to note the special tokens in serialization (similar to the need for configuration of pre-tokenizers).