### PR TITLE
Multiturn mm single image

### DIFF
--- a/torchchat/generate.py
+++ b/torchchat/generate.py
@@ -603,6 +603,7 @@ class Generator:
         if len(prompt.shape) > 1:
             prompt = prompt.squeeze(0)
         prompt_length = prompt.size(0)
+        max_new_tokens = min(max_new_tokens, max_seq_length - start_pos - prompt_length)
         # set up caches only if first inference
         if start_pos == 0:
             model = model.to(device=device)
@@ -825,6 +826,12 @@ class Generator:
                         content=content,
                     )
                 )
+        messages.append(
+            Message(
+                role="assistant",
+                content="",
+            )
+        )
 
         transform = llama3_2_vision_transform(str(self.tokenizer_args.tokenizer_path))
 
@@ -849,7 +856,7 @@ class Generator:
                 seq_len = encoded.size(0)
                 batch = {}
 
-            total_response_length = max_seq_len + max_new_tokens
+            total_response_length = seq_len + max_new_tokens
             batch["causal_mask"] = torch.nn.functional.pad(
                 torch.tril(
                     torch.ones(

--- a/torchchat/generate.py
+++ b/torchchat/generate.py
@@ -815,13 +815,13 @@ class Generator:
 
                 is_multimodal = images is not None
                 content = [{"type": "text", "content": prompt_arg}]
-                []
+                
                 if is_multimodal:
                     content = [{"type": "image", "content": images[0]}] + content
 
                 messages.append(
                     Message(
-                        role="user",
+                        role=message["role"],
                         content=content,
                     )
                 )

--- a/torchchat/usages/browser.py
+++ b/torchchat/usages/browser.py
@@ -10,6 +10,7 @@ logger.setLevel(logging.DEBUG)
 
 from openai import OpenAI
 
+st.set_page_config(page_title="torchchat", page_icon="🤖")
 st.title("torchchat")
 
 
@@ -26,14 +27,17 @@ def reset_chat():
     st.session_state["messages"] = start_state
     st.session_state["conversation_images"] = []
 
+
 if "messages" not in st.session_state:
     st.session_state.messages = start_state
 if "conversation_images" not in st.session_state:
     st.session_state.conversation_images = []
 
+
 def _upload_image_prompts(file_uploads):
     for file in file_uploads:
         st.session_state.conversation_images.append(file)
+
 
 with st.sidebar:
     if st.button("Reset Chat", type="primary"):
@@ -105,7 +109,6 @@ if prompt := st.chat_input():
         for img in st.session_state.conversation_images:
             st.image(img)
     st.session_state.conversation_images = []
-        
 
     with st.chat_message("assistant"), st.status(
         "Generating... ", expanded=True

--- a/torchchat/usages/openai_api.py
+++ b/torchchat/usages/openai_api.py
@@ -19,15 +19,15 @@ import torch
 
 from PIL import Image
 
+from torchtune.data import Message, padded_collate_tiled_images_and_mask
+
+from torchtune.models.llama3_2_vision._model_builders import llama3_2_vision_transform
+
 from torchchat.cli.download import is_model_downloaded, load_model_configs
 from torchchat.generate import Generator, GeneratorArgs
 from torchchat.model import FlamingoModel
 
 from torchchat.utils.build_utils import device_sync
-
-from torchtune.data import Message, padded_collate_tiled_images_and_mask
-
-from torchtune.models.llama3_2_vision._model_builders import llama3_2_vision_transform
 
 
 """Dataclasses defined around the objects used the OpenAI API Chat specification.
@@ -291,7 +291,9 @@ class OpenAiApiGenerator(Generator):
             )
         except:
             self.max_seq_length = 2048
-            print(f"can not find max_seq_length in model config, use default value: {self.max_seq_length}")
+            print(
+                f"can not find max_seq_length in model config, use default value: {self.max_seq_length}"
+            )
         # The System fingerprint is a unique identifier for the model and its configuration.
         self.system_fingerprint = (
             f"{self.builder_args.device}_{self.builder_args.precision}"
@@ -327,7 +329,9 @@ class OpenAiApiGenerator(Generator):
             for message in messages
         ]
 
-        return self._gen_model_input(prompt=prompt, max_new_tokens=completion_request.max_tokens)
+        return self._gen_model_input(
+            prompt=prompt, max_new_tokens=completion_request.max_tokens
+        )
 
     def chunked_completion(self, completion_request: CompletionRequest):
         """Handle a chat completion request and yield a chunked response.

--- a/torchchat/usages/openai_api.py
+++ b/torchchat/usages/openai_api.py
@@ -314,38 +314,20 @@ class OpenAiApiGenerator(Generator):
         if not isinstance(self.model, FlamingoModel):
             prompt = [
                 {"role": message["role"], "content": message["content"]}
-                for message in completion_request.messages
+                for message in messages
             ]
             return self._gen_model_input(
                 prompt=prompt, max_new_tokens=completion_request.max_tokens
             )
 
         # Llama 3.2 11B
-        prompt = None
-        images = None
 
-        for message in messages:
-            torchtune_contents = []
-            if isinstance(message["content"], list):
-                for content_dict in message["content"]:
-                    if content_dict["type"] == "text":
-                        assert (
-                            prompt is None
-                        ), "At most one text prompt is supported for each request"
-                        prompt = content_dict["text"]
-                    elif content_dict["type"] == "image_url":
-                        assert (
-                            images is None
-                        ), "At most one image is supported at the moment"
+        prompt = [
+            {"role": message["role"], "content": message["content"]}
+            for message in messages
+        ]
 
-                        base64_decoded = base64.b64decode(
-                            content_dict["image_url"].split(";base64,")[1]
-                        )
-                        images = [Image.open(BytesIO(base64_decoded))]
-
-        assert prompt is not None, "Text prompt must be specified in the request"
-
-        return self._gen_model_input(prompt, images, completion_request.max_tokens)
+        return self._gen_model_input(prompt=prompt, max_new_tokens=completion_request.max_tokens)
 
     def chunked_completion(self, completion_request: CompletionRequest):
         """Handle a chat completion request and yield a chunked response.


### PR DESCRIPTION
Multi-turn conversations were not working within the browser for LLaMA 3.2 Vision. This fixes this for the case of: 
- Text only conversation
- Conversation with one image prompt.
## Tests


| Model | Browser Test Text Only | Browser Test with Image | Generate CLI test |
| -------- | ------- | ------ | ------ |
| LLaMA 3.1 | ✅ | - | ✅ | 
| LLaMA 3.2 11B Vision | ✅ | ✅ | ✅ |

### CLI Tests

```
python3 torchchat.py generate llama3.2-11B --prompt "What's this?" --image-prompt assets/dog.jpg

/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/transformers/data/metrics/__init__.py:19: UserWarning: A NumPy version >=1.23.5 and <2.3.0 is required for this version of SciPy (detected version 1.23.2)
  from scipy.stats import pearsonr, spearmanr
2024-10-04:18:39:09,981 INFO     [sdpa_with_kv_cache.py:28] Loading custom ops library: /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/executorch/extension/llm/custom_ops/libcustom_ops_aot_lib.dylib
Using device=mps 
Loading model...
Time to load model: 38.54 seconds
-----------------------------------------------------------
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/torch/nn/functional.py:5096: UserWarning: MPS: The constant padding of more than 3 dimensions is not currently supported natively. It uses View Ops default implementation to run. This may have performance implications. (Triggered internally at /Users/runner/work/pytorch/pytorch/pytorch/aten/src/ATen/native/mps/operations/Pad.mm:465.)
  return torch._C._nn.pad(input, pad, mode, value)
What's this?The image depicts a dog riding a skateboard on a road, showcasing its unique and playful appearance.

* A dog:
        + Sitting on a skateboard
        + Wearing sunglasses
        + Has a blue collar around its neck
        + Ears perked up
        + Tongue out
* A skateboard:
        + Red in color
        + Has yellow wheels
        + Being ridden by the dog
* Sunglasses:
        + Pink in color
        + Worn by the dog

The image presents a lighthearted and humorous scene, with the dog's sunglasses and skateboard adding to its playful and carefree demeanor.2024-10-04:18:40:47,012 INFO     [generate.py:1138] 
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                
Generated 131 tokens                 
Time for inference 1: 56.0592 sec total                 
Time to first token: 14.2072 sec with parallel prefill.                

      Total throughput: 2.3547 tokens/sec, 0.4247 s/token                 
First token throughput: 0.0704 tokens/sec, 14.2072 s/token                 
 Next token throughput: 3.1301 tokens/sec, 0.3195 s/token                     
2024-10-04:18:40:47,012 INFO     [generate.py:1149] 
Bandwidth achieved: 50.14 GB/s
2024-10-04:18:40:47,012 INFO     [generate.py:1153] *** This first iteration will include cold start effects for dynamic import, hardware caches. ***

========================================


      Average tokens/sec (total): 2.35                 
Average tokens/sec (first token): 0.07                 
Average tokens/sec (next tokens): 3.13 
```
```
(.venv) puri@puri-mac torchchat % python3 torchchat.py generate --checkpoint-path /Users/puri/.torchchat/model-cache/stories15M/stories15M.pt --pte-path stories15M.pte
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/transformers/data/metrics/__init__.py:19: UserWarning: A NumPy version >=1.23.5 and <2.3.0 is required for this version of SciPy (detected version 1.23.2)
  from scipy.stats import pearsonr, spearmanr
^E2024-10-04:18:41:19,239 INFO     [sdpa_with_kv_cache.py:28] Loading custom ops library: /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/executorch/extension/llm/custom_ops/libcustom_ops_aot_lib.dylib
Warning: checkpoint path ignored because an exported DSO or PTE path specified
Warning: checkpoint path ignored because an exported DSO or PTE path specified
Using device=mps 
Loading model...
Cannot load specified PTE to mps. Attempting to load model to CPU instead
Time to load model: 0.05 seconds
[program.cpp:134] InternalConsistency verification requested but not available
-----------------------------------------------------------
Hello, my name is9 in the garden. The garden is very beautiful and all the flowers she blooms were so happy. One day, an old flower started to bloom. It was so beautiful that it fluttered around and around. Then, it was a small flower that bloomed in many different colors.
A few kids came to the garden and saw the beautiful flower. They thought it was so special, so they wanted to see it bloom. But the old flower was too high up on a tall tree, so they couldn't reach2024-10-04:18:41:19,824 INFO     [generate.py:1138] 
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                
Generated 109 tokens                 
Time for inference 1: 0.2679 sec total                 
Time to first token: 0.0256 sec with sequential prefill.                

      Total throughput: 410.6411 tokens/sec, 0.0024 s/token                 
First token throughput: 39.0747 tokens/sec, 0.0256 s/token                 
 Next token throughput: 449.8894 tokens/sec, 0.0022 s/token                     
2024-10-04:18:41:19,824 INFO     [generate.py:1149] 
Bandwidth achieved: 0.00 GB/s
2024-10-04:18:41:19,824 INFO     [generate.py:1153] *** This first iteration will include cold start effects for dynamic import, hardware caches. ***

========================================


      Average tokens/sec (total): 410.64                 
Average tokens/sec (first token): 39.07                 
Average tokens/sec (next tokens): 449.89 
```
```
(.venv) puri@puri-mac torchchat % python3 torchchat.py generate llama3 --prompt "Give me a table of 4 cold war era jets and their max speeds in km/h."                 
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/transformers/data/metrics/__init__.py:19: UserWarning: A NumPy version >=1.23.5 and <2.3.0 is required for this version of SciPy (detected version 1.23.2)
  from scipy.stats import pearsonr, spearmanr
2024-10-04:18:41:28,664 INFO     [sdpa_with_kv_cache.py:28] Loading custom ops library: /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/executorch/extension/llm/custom_ops/libcustom_ops_aot_lib.dylib
Using device=mps 
Loading model...
Time to load model: 27.24 seconds
-----------------------------------------------------------
Give me a table of 4 cold war era jets and their max speeds in km/h.Here is a table of 4 Cold War era jets and their maximum speeds in km/h:

| Aircraft | Country | Maximum Speed (km/h) |
| --- | --- | --- |
| Mikoyan-Gurevich MiG-15 | Soviet Union | 1,050 |
| North American F-86 Sabre | United States | 1,075 |
| Supermarine Swift F.7 | United Kingdom | 1,110 |
| Lockheed F-104 Starfighter | United States | 2,184 |

Note: The maximum speeds listed are approximate and may vary depending on the specific variant and configuration of each aircraft.2024-10-04:18:42:26,483 INFO     [generate.py:1138] 
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                
Generated 130 tokens                 
Time for inference 1: 30.2699 sec total                 
Time to first token: 1.5681 sec with parallel prefill.                

      Total throughput: 4.3277 tokens/sec, 0.2311 s/token                 
First token throughput: 0.6377 tokens/sec, 1.5681 s/token                 
 Next token throughput: 4.5293 tokens/sec, 0.2208 s/token                     
2024-10-04:18:42:26,483 INFO     [generate.py:1149] 
Bandwidth achieved: 69.51 GB/s
2024-10-04:18:42:26,483 INFO     [generate.py:1153] *** This first iteration will include cold start effects for dynamic import, hardware caches. ***

========================================


      Average tokens/sec (total): 4.33                 
Average tokens/sec (first token): 0.64                 
Average tokens/sec (next tokens): 4.53 
``` 


Tested with server + browser:
| Server Terminal | Browser Terminal | 
| -------- | ------- |
| ```python3 torchchat.py server llama3.2-11b``` | ```streamlit run torchchat/usages/browser.py```|

Single Image
<img width="570" alt="image" src="https://github.com/user-attachments/assets/166f89e2-f187-4669-aca5-c1d11a488c94">


Text Only

<img width="571" alt="image" src="https://github.com/user-attachments/assets/d28b06a0-f487-45f0-a120-3cc857c61df8">
