### PR TITLE
LLaMA 2 Chat Formatter List Message Content Fix

### DIFF
--- a/torchchat/generate.py
+++ b/torchchat/generate.py
@@ -103,7 +103,11 @@ class Llama2ChatFormatter(_ChatFormatter):
         tokens = self.tokenizer.encode(f"{B_INST} ")
         first_message = True  # Bool to handle placing the B_INST token. Behavior is weird - the system prompt should have the B_INST, but not the first user message. All following user messages *should* have it. Also, if there is no system prompt, then the user message should have it.
         for message in dialog:
-            content = message["content"].strip()
+            if isinstance(message["content"], list):
+                content = message["content"][0]["text"]
+            else:
+                content = message["content"]
+            content = content.strip()
             if message["role"] == "system":
                 encoded = self.tokenizer.encode(f"{B_SYS}\n{content}\n{E_SYS}")
                 first_message = False

--- a/torchchat/generate.py
+++ b/torchchat/generate.py
@@ -603,6 +603,7 @@ class Generator:
         if len(prompt.shape) > 1:
             prompt = prompt.squeeze(0)
         prompt_length = prompt.size(0)
+        max_new_tokens = min(max_new_tokens, max_seq_length - start_pos - prompt_length)
         # set up caches only if first inference
         if start_pos == 0:
             model = model.to(device=device)
@@ -825,6 +826,12 @@ class Generator:
                         content=content,
                     )
                 )
+        messages.append(
+            Message(
+                role="assistant",
+                content="",
+            )
+        )
 
         transform = llama3_2_vision_transform(str(self.tokenizer_args.tokenizer_path))
 
@@ -849,7 +856,7 @@ class Generator:
                 seq_len = encoded.size(0)
                 batch = {}
 
-            total_response_length = max_seq_len + max_new_tokens
+            total_response_length = seq_len + max_new_tokens
             batch["causal_mask"] = torch.nn.functional.pad(
                 torch.tril(
                     torch.ones(

--- a/torchchat/generate.py
+++ b/torchchat/generate.py
@@ -815,13 +815,13 @@ class Generator:
 
                 is_multimodal = images is not None
                 content = [{"type": "text", "content": prompt_arg}]
-                []
+                
                 if is_multimodal:
                     content = [{"type": "image", "content": images[0]}] + content
 
                 messages.append(
                     Message(
-                        role="user",
+                        role=message["role"],
                         content=content,
                     )
                 )

--- a/torchchat/usages/browser.py
+++ b/torchchat/usages/browser.py
@@ -10,6 +10,7 @@ logger.setLevel(logging.DEBUG)
 
 from openai import OpenAI
 
+st.set_page_config(page_title="torchchat", page_icon="🤖")
 st.title("torchchat")
 
 
@@ -26,14 +27,17 @@ def reset_chat():
     st.session_state["messages"] = start_state
     st.session_state["conversation_images"] = []
 
+
 if "messages" not in st.session_state:
     st.session_state.messages = start_state
 if "conversation_images" not in st.session_state:
     st.session_state.conversation_images = []
 
+
 def _upload_image_prompts(file_uploads):
     for file in file_uploads:
         st.session_state.conversation_images.append(file)
+
 
 with st.sidebar:
     if st.button("Reset Chat", type="primary"):
@@ -105,7 +109,6 @@ if prompt := st.chat_input():
         for img in st.session_state.conversation_images:
             st.image(img)
     st.session_state.conversation_images = []
-        
 
     with st.chat_message("assistant"), st.status(
         "Generating... ", expanded=True

--- a/torchchat/usages/openai_api.py
+++ b/torchchat/usages/openai_api.py
@@ -19,15 +19,15 @@ import torch
 
 from PIL import Image
 
+from torchtune.data import Message, padded_collate_tiled_images_and_mask
+
+from torchtune.models.llama3_2_vision._model_builders import llama3_2_vision_transform
+
 from torchchat.cli.download import is_model_downloaded, load_model_configs
 from torchchat.generate import Generator, GeneratorArgs
 from torchchat.model import FlamingoModel
 
 from torchchat.utils.build_utils import device_sync
-
-from torchtune.data import Message, padded_collate_tiled_images_and_mask
-
-from torchtune.models.llama3_2_vision._model_builders import llama3_2_vision_transform
 
 
 """Dataclasses defined around the objects used the OpenAI API Chat specification.
@@ -291,7 +291,9 @@ class OpenAiApiGenerator(Generator):
             )
         except:
             self.max_seq_length = 2048
-            print(f"can not find max_seq_length in model config, use default value: {self.max_seq_length}")
+            print(
+                f"can not find max_seq_length in model config, use default value: {self.max_seq_length}"
+            )
         # The System fingerprint is a unique identifier for the model and its configuration.
         self.system_fingerprint = (
             f"{self.builder_args.device}_{self.builder_args.precision}"
@@ -327,7 +329,9 @@ class OpenAiApiGenerator(Generator):
             for message in messages
         ]
 
-        return self._gen_model_input(prompt=prompt, max_new_tokens=completion_request.max_tokens)
+        return self._gen_model_input(
+            prompt=prompt, max_new_tokens=completion_request.max_tokens
+        )
 
     def chunked_completion(self, completion_request: CompletionRequest):
         """Handle a chat completion request and yield a chunked response.

--- a/torchchat/usages/openai_api.py
+++ b/torchchat/usages/openai_api.py
@@ -376,7 +376,7 @@ class OpenAiApiGenerator(Generator):
             encoded_prompt=encoded,
             temperature=float(completion_request.temperature),
             chat_mode=False,
-            sequential_prefill=False,
+            sequential_prefill=True,
         )
 
         def callback(x, *, done_generating=False):

--- a/torchchat/usages/openai_api.py
+++ b/torchchat/usages/openai_api.py
@@ -314,38 +314,20 @@ class OpenAiApiGenerator(Generator):
         if not isinstance(self.model, FlamingoModel):
             prompt = [
                 {"role": message["role"], "content": message["content"]}
-                for message in completion_request.messages
+                for message in messages
             ]
             return self._gen_model_input(
                 prompt=prompt, max_new_tokens=completion_request.max_tokens
             )
 
         # Llama 3.2 11B
-        prompt = None
-        images = None
 
-        for message in messages:
-            torchtune_contents = []
-            if isinstance(message["content"], list):
-                for content_dict in message["content"]:
-                    if content_dict["type"] == "text":
-                        assert (
-                            prompt is None
-                        ), "At most one text prompt is supported for each request"
-                        prompt = content_dict["text"]
-                    elif content_dict["type"] == "image_url":
-                        assert (
-                            images is None
-                        ), "At most one image is supported at the moment"
+        prompt = [
+            {"role": message["role"], "content": message["content"]}
+            for message in messages
+        ]
 
-                        base64_decoded = base64.b64decode(
-                            content_dict["image_url"].split(";base64,")[1]
-                        )
-                        images = [Image.open(BytesIO(base64_decoded))]
-
-        assert prompt is not None, "Text prompt must be specified in the request"
-
-        return self._gen_model_input(prompt, images, completion_request.max_tokens)
+        return self._gen_model_input(prompt=prompt, max_new_tokens=completion_request.max_tokens)
 
     def chunked_completion(self, completion_request: CompletionRequest):
         """Handle a chat completion request and yield a chunked response.


### PR DESCRIPTION
LLaMA2 Chat Formatter doesn't accept list-type message content. Since none of the LLaMA2 models are multimodal, we can be sure that the content type will be text. Simply forward the first text content of the message to the model

Tested using:


```
python3 torchchat.py server llama2   
```
and

```
streamlit run torchchat/usages/browser.py
```


<img width="800" alt="image" src="https://github.com/user-attachments/assets/4bc8f088-888f-4c49-90a4-73fe0f9aceca">
