### PR TITLE
Add check for rocminfo in the installation script to replace the nightly URL with the appropriate ROCm whl.

### DIFF
--- a/install/install_requirements.sh
+++ b/install/install_requirements.sh
@@ -69,7 +69,7 @@ then
   TORCH_NIGHTLY_URL="https://download.pytorch.org/whl/nightly/cu121"
 elif [[ -x "$(command -v rocminfo)" ]];
 then
-  TORCH_NIGHTLY_URL="https://download.pytorch.org/whl/rocm6.1"
+  TORCH_NIGHTLY_URL="https://download.pytorch.org/whl/nightly/rocm6.2"
 else
   TORCH_NIGHTLY_URL="https://download.pytorch.org/whl/nightly/cpu"
 fi

--- a/install/install_requirements.sh
+++ b/install/install_requirements.sh
@@ -67,6 +67,9 @@ TUNE_NIGHTLY_VERSION=dev20240928
 if [[ -x "$(command -v nvidia-smi)" ]];
 then
   TORCH_NIGHTLY_URL="https://download.pytorch.org/whl/nightly/cu121"
+elif [[ -x "$(command -v rocminfo)" ]];
+then
+  TORCH_NIGHTLY_URL="https://download.pytorch.org/whl/rocm6.1"
 else
   TORCH_NIGHTLY_URL="https://download.pytorch.org/whl/nightly/cpu"
 fi


### PR DESCRIPTION
On ROCm systems, running this script will not set up PyTorch with ROCm compatibility. This change should make users' experience smoother on AMD GPU systems. Will test on an AMD GPU system & update PR 