### PR TITLE
Add Prompt Template for Android Demo App

### DIFF
--- a/torchchat/edge/android/torchchat/app/src/main/java/org/pytorch/torchchat/MainActivity.java
+++ b/torchchat/edge/android/torchchat/app/src/main/java/org/pytorch/torchchat/MainActivity.java
@@ -204,7 +204,7 @@ public class MainActivity extends Activity implements Runnable, LlamaCallback {
         mSendButton.setText("Generate");
         mSendButton.setOnClickListener(
                 view -> {
-                    String prompt = mEditTextMessage.getText().toString();
+                    String prompt = mEditTextMessage.getText().toString() + "<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
                     mMessageAdapter.add(new Message(prompt, true));
                     mMessageAdapter.notifyDataSetChanged();
                     mEditTextMessage.setText("");


### PR DESCRIPTION
Adds a basic template to the Android Demo app to simulate a chat response.

Without the template, llama models default to a basic completion inference which isn't the behaviors users expect when using the demo app

---
I would love for someone to verify on device that they are seeing expected behavior (and sharing a screenshot)