### PR TITLE
Remove numpy < 2.0 pin to align with pytorch

### DIFF
--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -12,7 +12,7 @@ tiktoken
 # Miscellaneous
 snakeviz
 sentencepiece
-numpy < 2.0
+numpy
 gguf
 blobfile
 tomli >= 1.1.0 ; python_version < "3.11"


### PR DESCRIPTION
Fix #1296

Align with https://github.com/pytorch/pytorch/blame/main/requirements.txt#L5