### PR TITLE
Unbreak gguf util CI job by fixing numpy version

### DIFF
--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -12,7 +12,8 @@ tiktoken
 # Miscellaneous
 snakeviz
 sentencepiece
-numpy
+# numpy version range required by GGUF util
+numpy >= 1.17, < 2.0
 gguf
 blobfile
 tomli >= 1.1.0 ; python_version < "3.11"


### PR DESCRIPTION
Setting numpy version to be the range required by gguf: https://github.com/ggerganov/llama.cpp/blob/master/gguf-py/pyproject.toml