### PR TITLE
[downloads] remove obsolete hf param for using symlinks (local_dir_use_symlinks=False,) and avoid showing warning about it

### DIFF
--- a/torchchat/cli/download.py
+++ b/torchchat/cli/download.py
@@ -10,7 +10,10 @@ import urllib.request
 from pathlib import Path
 from typing import Optional
 
-from torchchat.cli.convert_hf_checkpoint import convert_hf_checkpoint, convert_hf_checkpoint_to_tune
+from torchchat.cli.convert_hf_checkpoint import (
+    convert_hf_checkpoint,
+    convert_hf_checkpoint_to_tune,
+)
 from torchchat.model_config.model_config import (
     load_model_configs,
     ModelConfig,
@@ -57,7 +60,6 @@ def _download_hf_snapshot(
         snapshot_download(
             model_config.distribution_path,
             local_dir=artifact_dir,
-            local_dir_use_symlinks=False,
             token=hf_token,
             ignore_patterns=ignore_patterns,
         )
@@ -77,9 +79,14 @@ def _download_hf_snapshot(
             raise e
 
     # Convert the Multimodal Llama model to the torchtune format.
-    if model_config.name in {"meta-llama/Llama-3.2-11B-Vision-Instruct", "meta-llama/Llama-3.2-11B-Vision"}:
+    if model_config.name in {
+        "meta-llama/Llama-3.2-11B-Vision-Instruct",
+        "meta-llama/Llama-3.2-11B-Vision",
+    }:
         print(f"Converting {model_config.name} to torchtune format...", file=sys.stderr)
-        convert_hf_checkpoint_to_tune( model_dir=artifact_dir, model_name=model_config.name)
+        convert_hf_checkpoint_to_tune(
+            model_dir=artifact_dir, model_name=model_config.name
+        )
 
     else:
         # Convert the model to the torchchat format.


### PR DESCRIPTION
This PR:
1 - removes the now obsolete local_dir_use_symlinks from the hf snapshot_download api call.  
2 - this then removes the currently displayed long warning about using it which is shown to the user when running torchchat.py download...

Before this PR:
~~~
[less@devgpu011.cco3 /data/users/less/local/chatmaster (main)]$ python torchchat.py download llama3
Downloading meta-llama/Meta-Llama-3-8B-Instruct from HuggingFace...
/home/less/local/miniconda3/envs/newserver/lib/python3.10/site-packages/huggingface_hub/file_download.py:1212: ****UserWarning: `local_dir_use_symlinks` parameter is deprecated and will be ignored. 
The process to download files to a local folder has been updated and do not rely on symlinks anymore. 
You only need to pass a destination folder as`local_dir`.
For more details, check out https://huggingface.co/docs/huggingface_hub/main/en/guides/download#download-files-to-local-folder**.**
~~~

After this PR - no warning, just downloading:
~~~
[less@devgpu011.cco3 /data/users/less/local/chatmaster (main)]$ python torchchat.py download llama3.1
Downloading meta-llama/Meta-Llama-3.1-8B-Instruct from HuggingFace...
~~~

3 - two additional lines were auto reformatted by my VS code and I don't have control over that (auto does it whenever I save a file now) but no change in functionality there.
