### PR TITLE
Deprecating Int8DynActInt4WeightQuantizer

### DIFF
--- a/torchchat/generate.py
+++ b/torchchat/generate.py
@@ -1160,17 +1160,9 @@ class Generator:
                 t - aggregate_metrics.get("time_to_first_token", 0)
             )
 
-            if jit_compile:
-                print(
-                    f"just-in-time compilation time (incl run time): {compilation_time:.2} seconds"
-                )
-                aggregate_metrics["tokens_per_sec_jit_compile"] = tokens_sec
-                # Don't continue here.... because we need to report and reset
-                # continue
-            else:
-                aggregate_metrics["tokens_per_sec"].append(tokens_sec)
-                aggregate_metrics["first_token_per_sec"].append(first_token_sec)
-                aggregate_metrics["next_tokens_per_sec"].append(next_tokens_sec)
+            aggregate_metrics["tokens_per_sec"].append(tokens_sec)
+            aggregate_metrics["first_token_per_sec"].append(first_token_sec)
+            aggregate_metrics["next_tokens_per_sec"].append(next_tokens_sec)
 
             logging.info(
                 f"\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\


### PR DESCRIPTION
Summary:
Added torchao API int8_dynamic_activation_int4_weight I ran some benchmark with eager mode and there was some accuracy loss and some slowdowns in compile.

But later I found we only care about performance on executorch. So was trying to benchmark et perf and accuracy. but I can't get the env setup correctly for executorch to run the experiments

Specifically there were some issues when I'm trying to run the following after I installed executorch from pip
```
python3 torchchat.py export llama3.1 --quantize torchchat/quant_config/mobile.json --output-pte-path llama3.1.pte
```

Error:
```
Traceback (most recent call last):
  File "/data/users/jerryzh/torchchat/torchchat.py", line 17, in <module>
    from torchchat.cli.cli import (
  File "/data/users/jerryzh/torchchat/torchchat/cli/cli.py", line 14, in <module>
    import torch
  File "/home/jerryzh/.conda/envs/torchchat/lib/python3.10/site-packages/torch/__init__.py", line 368, in <module>
    from torch._C import *  # noqa: F403
ImportError: /home/jerryzh/.conda/envs/torchchat/lib/python3.10/site-packages/torch/lib/../../nvidia/cusparse/lib/libcusparse.so.12: undefined symbol: __nvJitLinkComplete_12_4, version libnvJitLink.so.12
```

Test Plan:
test instruction from Jack: https://docs.google.com/document/d/1eRAoY1Jq4SR5A7iAYC71maSZAPzsBJmr9VuZPhR5ZYA/edit?tab=t.0#bookmark=id.otk3jomaciya

Reviewers:

Subscribers:

Tasks:

Tags: