### PR TITLE
Minor fixes to PT2 export path: enum typo and max_seq_len

### DIFF
--- a/torchchat/export.py
+++ b/torchchat/export.py
@@ -78,11 +78,11 @@ def export_for_server(
             dynamic_shapes=dynamic_shapes,
             options=options,
         )
-        
+
         if package:
             from torch._inductor.package import package_aoti
             path = package_aoti(output_path, path)
-    
+
     print(f"The generated packaged model can be found at: {path}")
     return path
 
@@ -382,7 +382,7 @@ def main(args):
 
         if builder_args.max_seq_length is None:
             if (
-                output_dso_path is not None
+                (output_dso_path is not None or output_aoti_package_path is not None)
                 and not builder_args.dynamic_shapes
             ):
                 print("Setting max_seq_length to 300 for DSO export.")


### PR DESCRIPTION
2 mini fixes on https://github.com/pytorch/torchchat/pull/896
* Enum logic typos (was not found when testing originally due to Python magic)
* max_seq_len discrepancy (found when testing)

```
python3 torchchat.py export llama3.1 --quantize '{"precision": {"dtype":"bfloat16"}, "executor":{"accelerator":"cuda"}}' --output-aoti-package-path /tmp/model3.pt2

python3 torchchat.py generate llama3.1 --aoti-package-path /tmp/model3.pt2 --prompt "Once upon a time,"  --num-samples 3
```

Compared to 
```
python3 torchchat.py export llama3.1 --quantize '{"precision": {"dtype":"bfloat16"}, "executor":{"accelerator":"cuda"}}' --output-dso-path /tmp/model3.so

python3 torchchat.py generate llama3.1 --dso-path /tmp/model3.so --prompt "Once upon a time,"  --num-samples 3
```