### PR TITLE
fix: allow multiple weight mapping files for mistral

### DIFF
--- a/torchchat/cli/convert_hf_checkpoint.py
+++ b/torchchat/cli/convert_hf_checkpoint.py
@@ -43,7 +43,8 @@ def convert_hf_checkpoint(
 
     # Load the json file containing weight mapping
     model_map_json_matches = [Path(m) for m in glob.glob(str(model_dir / "*.index.json"))]
-    assert len(model_map_json_matches) <= 1, "Found multiple weight mapping files"
+    if "mistral" not in model_name:
+        assert len(model_map_json_matches) <= 1, "Found multiple weight mapping files"
     if len(model_map_json_matches):
         model_map_json = model_map_json_matches[0]
     else:


### PR DESCRIPTION
42f18114 fix: allow multiple weight mapping files for mistral

commit 42f181148b5a077adde5132f66575c64807ac260
Author: Sébastien Han <seb@redhat.com>
Date:   Wed Nov 6 15:20:28 2024 +0100

    fix: allow multiple weight mapping files for mistral
    
    Downloading a Mistral model fails because it includes multiple weight
    mapping files. The regression was introduced in commit
    `766bee9f4a1fcb187fae543a525495d3ff482097`. I'm unclear on the original
    intent, but perhaps the exception was meant to apply only to Granite
    models. This isn’t an ideal fix, but it does enable Mistral to be
    downloaded and used for chat.
    
    Signed-off-by: Sébastien Han <seb@redhat.com>
