### PR TITLE
Minor typo + Update install_requirements.sh to support python 3.10 >=

### DIFF
--- a/install/install_requirements.sh
+++ b/install/install_requirements.sh
@@ -19,14 +19,14 @@ fi
 echo "Using python executable: $PYTHON_EXECUTABLE"
 
 PYTHON_SYS_VERSION="$($PYTHON_EXECUTABLE -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")"
-# Check python version. Expect 3.10.x or 3.11.x
+# Check python version. Expect 3.10.x to 3.12.x. Note 3.13 may work, but no guarantees
 if ! $PYTHON_EXECUTABLE -c "
 import sys
-if sys.version_info < (3, 10) or sys.version_info >= (3, 12):
+if sys.version_info < (3, 10) or sys.version_info >= (3, 13):
     sys.exit(1)
 ";
 then
-  echo "Python version must be 3.10.x or 3.11.x. Detected version: $PYTHON_SYS_VERSION"
+  echo "Python version must be between 3.10.x and 3.12.x. Detected version: $PYTHON_SYS_VERSION"
   exit 1
 fi
 

--- a/install/install_requirements.sh
+++ b/install/install_requirements.sh
@@ -21,14 +21,14 @@ fi
 echo "Using python executable: $PYTHON_EXECUTABLE"
 
 PYTHON_SYS_VERSION="$($PYTHON_EXECUTABLE -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")"
-# Check python version. Expect greater than 3.10.x
+# Check python version. Expect at least 3.10.x
 if ! $PYTHON_EXECUTABLE -c "
 import sys
 if sys.version_info < (3, 10):
     sys.exit(1)
 ";
 then
-  echo "Python version must be greater than 3.10.x. Detected version: $PYTHON_SYS_VERSION"
+  echo "Python version must be at least 3.10.x. Detected version: $PYTHON_SYS_VERSION"
   exit 1
 fi
 

--- a/install/install_requirements.sh
+++ b/install/install_requirements.sh
@@ -14,19 +14,21 @@ then
   if [[ -z ${CONDA_DEFAULT_ENV:-} ]] || [[ ${CONDA_DEFAULT_ENV:-} == "base" ]] || [[ ! -x "$(command -v python)" ]];
   then
     PYTHON_EXECUTABLE=python3
+  else
+    PYTHON_EXECUTABLE=python
   fi
 fi
 echo "Using python executable: $PYTHON_EXECUTABLE"
 
 PYTHON_SYS_VERSION="$($PYTHON_EXECUTABLE -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")"
-# Check python version. Expect 3.10.x to 3.12.x. Note 3.13 may work, but no guarantees
+# Check python version. Expect greater than 3.10.x
 if ! $PYTHON_EXECUTABLE -c "
 import sys
-if sys.version_info < (3, 10) or sys.version_info >= (3, 13):
+if sys.version_info < (3, 10):
     sys.exit(1)
 ";
 then
-  echo "Python version must be between 3.10.x and 3.12.x. Detected version: $PYTHON_SYS_VERSION"
+  echo "Python version must be greater than 3.10.x. Detected version: $PYTHON_SYS_VERSION"
   exit 1
 fi
 


### PR DESCRIPTION
Minor fixes to install_requirement (undefined variable) + Loosen the Python requirements to 3.10.0+
* We can case out specific Python version as needed, but no need to restrict preemptively

---
Fails with 3.8
```
./install/install_requirements.sh
Using python executable: python3
Python version must be greater than 3.10.x. Detected version: 3.8
```

Works with 3.10.0