### PR TITLE
fix: allow installing on python 3.12

### DIFF
--- a/install/install_requirements.sh
+++ b/install/install_requirements.sh
@@ -19,14 +19,14 @@ fi
 echo "Using python executable: $PYTHON_EXECUTABLE"
 
 PYTHON_SYS_VERSION="$($PYTHON_EXECUTABLE -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")"
-# Check python version. Expect 3.10.x or 3.11.x
+# Check python version. Expect 3.10.x, 3.11.x or 3.12.x
 if ! $PYTHON_EXECUTABLE -c "
 import sys
-if sys.version_info < (3, 10) or sys.version_info >= (3, 12):
+if sys.version_info < (3, 10) or sys.version_info >= (3, 13):
     sys.exit(1)
 ";
 then
-  echo "Python version must be 3.10.x or 3.11.x. Detected version: $PYTHON_SYS_VERSION"
+  echo "Python version must be 3.10.x, 3.11.x or 3.12.x. Detected version: $PYTHON_SYS_VERSION"
   exit 1
 fi
 


### PR DESCRIPTION
3c02e8c3 fix: allow installing on python 3.12

commit 3c02e8c3a1ce7143ed1461a6c45563446c6253ad
Author: Sébastien Han <seb@redhat.com>
Date:   Wed Nov 13 09:55:40 2024 +0100

    fix: allow installing on python 3.12
    
    It was reported that running on Python 3.12 is acceptable and supported
    by the project. So we now open up the installation on Python 3.12 too.
    
    Signed-off-by: Sébastien Han <seb@redhat.com>
