### PR TITLE
fix: remove dup dependency

### DIFF
--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -14,7 +14,6 @@ snakeviz
 sentencepiece
 # numpy version range required by GGUF util
 numpy >= 1.17, < 2.0
-gguf
 blobfile
 tomli >= 1.1.0 ; python_version < "3.11"
 openai


### PR DESCRIPTION
f6aa8f3d fix: remove dup dependency

commit f6aa8f3d65674c7e4f7553c38e9d8ef9d7e5ee13
Author: Sébastien Han <seb@redhat.com>
Date:   Wed Nov 13 10:05:07 2024 +0100

    fix: remove dup dependency
    
    `gguf` was listed twice on the dependency list.
    
    Signed-off-by: Sébastien Han <seb@redhat.com>
