### PR TITLE
fix: mark model argument as mandatory

### DIFF
--- a/torchchat/cli/download.py
+++ b/torchchat/cli/download.py
@@ -110,6 +110,8 @@ def _download_direct(
 def download_and_convert(
     model: str, models_dir: Path, hf_token: Optional[str] = None
 ) -> None:
+    if model is None:
+        raise ValueError("'download' command needs a model name or alias.")
     model_config = resolve_model_config(model)
     model_dir = models_dir / model_config.name
 
@@ -234,4 +236,8 @@ def where_main(args) -> None:
 
 # Subcommand to download model artifacts.
 def download_main(args) -> None:
-    download_and_convert(args.model, args.model_directory, args.hf_token)
+    try:
+        download_and_convert(args.model, args.model_directory, args.hf_token)
+    except ValueError as e:
+        print(e, file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
8a45be1b fix: mark model argument as mandatory

commit 8a45be1bfcd2d94b057b0ae9e40a491b376aa778
Author: Sébastien Han <seb@redhat.com>
Date:   Wed Nov 13 11:02:47 2024 +0100

    fix: mark model argument as mandatory
    
    Let's gracefully fail if no model is given to the `download` command.
    
    Signed-off-by: Sébastien Han <seb@redhat.com>
