### PR TITLE
Bug Fix: Check for explicit cli device (fast)

### DIFF
--- a/torchchat/cli/cli.py
+++ b/torchchat/cli/cli.py
@@ -533,7 +533,7 @@ def arg_init(args):
         # Localized import to minimize expensive imports
         from torchchat.utils.build_utils import get_device_str
 
-        if args.device is None:
+        if args.device is None or args.device == "fast":
             args.device = get_device_str(
                 args.quantize.get("executor", {}).get("accelerator", default_device)
             )


### PR DESCRIPTION
This fixes a bug where a user provided "fast" device arg falls through without being converted to a device. This correctly catches this case.

Bug introduced in https://github.com/pytorch/torchchat/commit/93f713f12507b5cef18a42c411030c90b9326369, 

---
Command
```
python3 torchchat.py generate llama3.1 --prompt "write me a story about a boy and his bear" --device fast
```

Original Failure:
```
RuntimeError: don't know how to restore data location of torch.storage.UntypedStorage (tagged with fast)
```