### PR TITLE
Bug fix: Enable fast to override quantize json

### DIFF
--- a/torchchat/cli/cli.py
+++ b/torchchat/cli/cli.py
@@ -533,15 +533,16 @@ def arg_init(args):
         # Localized import to minimize expensive imports
         from torchchat.utils.build_utils import get_device_str
 
-        if args.device is None or args.device == "fast":
+        if args.device is None:
             args.device = get_device_str(
                 args.quantize.get("executor", {}).get("accelerator", default_device)
             )
         else:
+            args.device = get_device_str(args.device)
             executor_handler = args.quantize.get("executor", None)
             if executor_handler:
                 if executor_handler["accelerator"] != args.device:
-                    print('overriding json-specified device {executor_handler["accelerator"]} with cli device {args.device}')
+                    print(f'overriding json-specified device {executor_handler["accelerator"]} with cli device {args.device}')
                     executor_handler["accelerator"] = args.device
 
     if "mps" in args.device:

--- a/torchchat/cli/cli.py
+++ b/torchchat/cli/cli.py
@@ -540,10 +540,9 @@ def arg_init(args):
         else:
             args.device = get_device_str(args.device)
             executor_handler = args.quantize.get("executor", None)
-            if executor_handler:
-                if executor_handler["accelerator"] != args.device:
-                    print(f'overriding json-specified device {executor_handler["accelerator"]} with cli device {args.device}')
-                    executor_handler["accelerator"] = args.device
+            if executor_handler and executor_handler["accelerator"] != args.device:
+                print(f'overriding json-specified device {executor_handler["accelerator"]} with cli device {args.device}')
+                executor_handler["accelerator"] = args.device
 
     if "mps" in args.device:
         if getattr(args, "compile", False) or getattr(args, "compile_prefill", False):


### PR DESCRIPTION
Follow up fix for: https://github.com/pytorch/torchchat/commit/46977645de6e9e29e58fada7d600c1930ed6f67b

We want to allow "fast" to work as a manual overwrite of a `--quantize` accelerator config, which the previous PR disabled while fixing a different bug

---
No overwrite
```
python3 torchchat.py generate llama3.1 --quantize '{"precision": {"dtype":"float16"}, "executor":{"accelerator":"mps"}}'

NumExpr defaulting to 10 threads.
PyTorch version 2.6.0.dev20241002 available.
lm_eval is not installed, GPTQ may not be usable
Using device=mps
```

Overwrite with device arg
```
python3 torchchat.py generate llama3.1 --quantize '{"precision": {"dtype":"float16"}, "executor":{"accelerator":"mps"}}' --device cpu

overriding json-specified device mps with cli device cpu
NumExpr defaulting to 10 threads.
PyTorch version 2.6.0.dev20241002 available.
lm_eval is not installed, GPTQ may not be usable
Using device=cpu Apple M1 Max
```

Overwrite with fast arg
```
python3 torchchat.py generate llama3.1 --quantize '{"precision": {"dtype":"float16"}, "executor":{"accelerator":"cpu"}}' --device fast

overriding json-specified device cpu with cli device mps
NumExpr defaulting to 10 threads.
PyTorch version 2.6.0.dev20241002 available.
lm_eval is not installed, GPTQ may not be usable
Using device=mps
```

Run with fast arg (same as running without device arg)
```
python3 torchchat.py generate llama3.1 --device fast

NumExpr defaulting to 10 threads.
PyTorch version 2.6.0.dev20241002 available.
lm_eval is not installed, GPTQ may not be usable
Using device=mps
```