### PR TITLE
Remove tokens per sec in aggregate_metrics when jit_compile

### DIFF
--- a/torchchat/generate.py
+++ b/torchchat/generate.py
@@ -1149,9 +1149,11 @@ class Generator:
                 print(
                     f"just-in-time compilation time (incl run time): {compilation_time:.2} seconds"
                 )
-            aggregate_metrics["tokens_per_sec"].append(tokens_sec)
-            aggregate_metrics["first_token_per_sec"].append(first_token_sec)
-            aggregate_metrics["next_tokens_per_sec"].append(next_tokens_sec)
+            else:
+                # aggregate_metrics will not append when is jit_compile, which will affect the average numbers.
+                aggregate_metrics["tokens_per_sec"].append(tokens_sec)
+                aggregate_metrics["first_token_per_sec"].append(first_token_sec)
+                aggregate_metrics["next_tokens_per_sec"].append(next_tokens_sec)
 
             logging.info(
                 f"\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\

--- a/torchchat/generate.py
+++ b/torchchat/generate.py
@@ -1207,7 +1207,8 @@ with {'sequential' if generator_args.sequential_prefill else 'parallel'} prefill
             or torch.isnan(torch.tensor(avg_next_tokens_sec))
         ):
             print(
-                f"\n      Average tokens/sec (total): {avg_tokens_sec:.2f} \
+                f"\nWarning: The averages were calculated with the compile sample excluded. \
+                \n      Average tokens/sec (total): {avg_tokens_sec:.2f} \
                 \nAverage tokens/sec (first token): {avg_first_token_sec:.2f} \
                 \nAverage tokens/sec (next tokens): {avg_next_tokens_sec:.2f} \n\
                 "

--- a/torchchat/generate.py
+++ b/torchchat/generate.py
@@ -1207,7 +1207,7 @@ with {'sequential' if generator_args.sequential_prefill else 'parallel'} prefill
             or torch.isnan(torch.tensor(avg_next_tokens_sec))
         ):
             print(
-                f"\nWarning: The averages were calculated with the compile sample excluded. \
+                f"\nWarning: Excluding compile in calculations \
                 \n      Average tokens/sec (total): {avg_tokens_sec:.2f} \
                 \nAverage tokens/sec (first token): {avg_first_token_sec:.2f} \
                 \nAverage tokens/sec (next tokens): {avg_next_tokens_sec:.2f} \n\


### PR DESCRIPTION
This PR is to remove tokens per sec in aggregate_metrics when jit_compile, to make the average of tokens per sec more precise. The tokens per sec is too low when jit_compile, which should not be included in aggregate_metrics.