### PR TITLE
Add missing include for compile on Ubuntu 24.04

### DIFF
--- a/tokenizer/base64.h
+++ b/tokenizer/base64.h
@@ -27,6 +27,7 @@
 #include <cassert>
 #include <string>
 #include <string_view>
+#include <cstdint>
 
 namespace base64 {
 


### PR DESCRIPTION
Adding the include for cstdint that fixes #985.  This seems like a trivial issue caused by different libc++ and libstdc++ including standard integer types differently, so why not include it?