### PR TITLE
Changing the referenced AAR so that it uses the AAR from the docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ runner-et/cmake-out/*
 runner-aoti/cmake-out/*
 cmake-out/
 
+# Example project Android Studio ignore
+torchchat/edge/android/torchchat/.idea/*
+
+
 # pte files
 *.pte
 

--- a/torchchat/edge/android/torchchat/app/build.gradle.kts
+++ b/torchchat/edge/android/torchchat/app/build.gradle.kts
@@ -57,7 +57,7 @@ dependencies {
   implementation("androidx.constraintlayout:constraintlayout:2.2.0-alpha12")
   implementation("com.facebook.fbjni:fbjni:0.5.1")
   implementation("com.google.code.gson:gson:2.8.6")
-  implementation(files("libs/executorch-llama.aar"))
+  implementation(files("libs/executorch.aar"))
   implementation("com.google.android.material:material:1.12.0")
   implementation("androidx.activity:activity:1.9.0")
   testImplementation("junit:junit:4.13.2")


### PR DESCRIPTION
- Trivial edit to ignore the .idea directory when opening torchchat with Android Studio.
- Renamed the AAR referenced so that it's consistent with the instructions provided in the README for deploying on Android