### PR TITLE
Fix 3.2 11B inference, via fixing padded_collate_tiled_images_and_mask args

### DIFF
--- a/torchchat/generate.py
+++ b/torchchat/generate.py
@@ -949,7 +949,7 @@ class Generator:
 
             if image_found:
                 batch = padded_collate_tiled_images_and_mask(
-                    [data], pad_direction="left", pad_max_images=1
+                    [data], pad_direction="left", pad_max_images=1, pad_max_tiles=transform.max_num_tiles
                 )
                 encoded = batch.pop("tokens").to(device).view(-1)
                 seq_len = encoded.size(0)


### PR DESCRIPTION
Added in torchtune: https://github.com/pytorch/torchtune/pull/1920/files#diff-cd102796d289ebc2a317cc54b78a33ae298a4d7c9c3181f4e3be5f781420d146L155

Picked up in pin bump https://github.com/pytorch/torchchat/commit/bb72b096b14f0c9753070f3523e43ed58aa55178

Fixes: 
```
python torchchat.py generate llama3.2-11B --prompt "What's in this image?" --image-prompt assets/dog.jpg  --num-samples 
```