### PR TITLE
Fix how stream flag is read from request

### DIFF
--- a/torchchat/usages/openai_api.py
+++ b/torchchat/usages/openai_api.py
@@ -180,7 +180,10 @@ class CompletionRequest:
     user: Optional[str] = None  # unimplemented
 
     def __post_init__(self):
-        self.stream = bool(self.stream)
+        if isinstance(self.stream, str):
+            self.stream = self.stream.lower() != "false"
+        else:
+            self.stream = bool(self.stream)
 
 
 @dataclass


### PR DESCRIPTION
This PR fixes how the stream flag is read from a request. Sending a request like:
```
curl http://localhost:5000/v1/chat/completions   -H "Content-Type: application/json"   -d '{
    "model": "llama3.1",
    "stream": "False",
    "max_tokens": 200,
    "messages": [
      {
        "role": "system",
        "content": "You are a helpful assistant."
      },
      {
        "role": "user",
        "content": "Hello!"
      }
    ]
  }'
```
currently results in a streaming response as a non-empty string (like 'False') is interpreted  by bool() as True.