### PR TITLE
Update run-readme-pr-linuxaarch64.yml to use correct runner

### DIFF
--- a/.github/workflows/run-readme-pr-linuxaarch64.yml
+++ b/.github/workflows/run-readme-pr-linuxaarch64.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   test-readme-cpu:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    permissions:
+      id-token: write
+      contents: read
     with:
       runner: linux.arm64.m7g.4xlarge
       docker-image: "pytorch/manylinux2_28_aarch64-builder:cuda12.6"
@@ -35,6 +38,9 @@ jobs:
 
   test-quantization-cpu:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    permissions:
+      id-token: write
+      contents: read
     with:
       runner: linux.arm64.2xlarge
       docker-image: "pytorch/manylinux2_28_aarch64-builder:cpu-aarch64-main"

--- a/.github/workflows/run-readme-pr-linuxaarch64.yml
+++ b/.github/workflows/run-readme-pr-linuxaarch64.yml
@@ -11,7 +11,7 @@ jobs:
   test-readme-cpu:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
-      runner: linux.arm64.2xlarge
+      runner: linux.arm64.m7g.4xlarge
       gpu-arch-type: cuda
       gpu-arch-version: "12.1"
       timeout: 60
@@ -35,7 +35,7 @@ jobs:
   test-quantization-cpu:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
-      runner: linux.arm64.2xlarge
+      runner: linux.arm64.m7g.4xlarge
       gpu-arch-type: cuda
       gpu-arch-version: "12.1"
       timeout: 60
@@ -54,7 +54,7 @@ jobs:
   test-gguf-cpu:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
-      runner: linux.arm64.2xlarge
+      runner: linux.arm64.m7g.4xlarge
       gpu-arch-type: cuda
       gpu-arch-version: "12.1"
       timeout: 60
@@ -78,7 +78,7 @@ jobs:
   test-advanced-cpu:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
-      runner: linux.arm64.2xlarge
+      runner: linux.arm64.m7g.4xlarge
       gpu-arch-type: cuda
       gpu-arch-version: "12.1"
       timeout: 60
@@ -102,7 +102,7 @@ jobs:
   test-evaluation-cpu:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
-      runner: linux.arm64.2xlarge
+      runner: linux.arm64.m7g.4xlarge
       gpu-arch-type: cuda
       gpu-arch-version: "12.1"
       timeout: 60

--- a/.github/workflows/run-readme-pr-linuxaarch64.yml
+++ b/.github/workflows/run-readme-pr-linuxaarch64.yml
@@ -13,7 +13,7 @@ jobs:
     with:
       runner: linux.arm64.m7g.4xlarge
       docker-image: "pytorch/manylinuxaarch64-builder:cuda12.6-main"
-      gpu-arch-type: cuda
+      gpu-arch-type: cuda-aarch64
       gpu-arch-version: "12.6"
       timeout: 60
       script: |
@@ -38,7 +38,7 @@ jobs:
     with:
       runner: linux.arm64.m7g.4xlarge
       docker-image: "pytorch/manylinuxaarch64-builder:cuda12.6-main"
-      gpu-arch-type: cuda
+      gpu-arch-type: cuda-aarch64
       gpu-arch-version: "12.6"
       timeout: 60
       script: |
@@ -58,7 +58,7 @@ jobs:
     with:
       runner: linux.arm64.m7g.4xlarge
       docker-image: "pytorch/manylinuxaarch64-builder:cuda12.6-main"
-      gpu-arch-type: cuda
+      gpu-arch-type: cuda-aarch64
       gpu-arch-version: "12.6"
       timeout: 60
       script: |
@@ -83,7 +83,7 @@ jobs:
     with:
       runner: linux.arm64.m7g.4xlarge
       docker-image: "pytorch/manylinuxaarch64-builder:cuda12.6-main"
-      gpu-arch-type: cuda
+      gpu-arch-type: cuda-aarch64
       gpu-arch-version: "12.6"
       timeout: 60
       script: |
@@ -108,7 +108,7 @@ jobs:
     with:
       runner: linux.arm64.m7g.4xlarge
       docker-image: "pytorch/manylinuxaarch64-builder:cuda12.6-main"
-      gpu-arch-type: cuda
+      gpu-arch-type: cuda-aarch64
       gpu-arch-version: "12.6"
       timeout: 60
       script: |

--- a/.github/workflows/run-readme-pr-linuxaarch64.yml
+++ b/.github/workflows/run-readme-pr-linuxaarch64.yml
@@ -12,9 +12,9 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
       runner: linux.arm64.m7g.4xlarge
-      docker-image: "pytorch/manylinuxaarch64-builder:cuda12.1-main"
+      docker-image: "pytorch/manylinuxaarch64-builder:cuda12.6-main"
       gpu-arch-type: cuda
-      gpu-arch-version: "12.1"
+      gpu-arch-version: "12.6"
       timeout: 60
       script: |
         echo "::group::Print machine info"
@@ -37,9 +37,9 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
       runner: linux.arm64.m7g.4xlarge
-      docker-image: "pytorch/manylinuxaarch64-builder:cuda12.1-main"
+      docker-image: "pytorch/manylinuxaarch64-builder:cuda12.6-main"
       gpu-arch-type: cuda
-      gpu-arch-version: "12.1"
+      gpu-arch-version: "12.6"
       timeout: 60
       script: |
         echo "::group::Print machine info"
@@ -57,9 +57,9 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
       runner: linux.arm64.m7g.4xlarge
-      docker-image: "pytorch/manylinuxaarch64-builder:cuda12.1-main"
+      docker-image: "pytorch/manylinuxaarch64-builder:cuda12.6-main"
       gpu-arch-type: cuda
-      gpu-arch-version: "12.1"
+      gpu-arch-version: "12.6"
       timeout: 60
       script: |
         echo "::group::Print machine info"
@@ -82,9 +82,9 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
       runner: linux.arm64.m7g.4xlarge
-      docker-image: "pytorch/manylinuxaarch64-builder:cuda12.1-main"
+      docker-image: "pytorch/manylinuxaarch64-builder:cuda12.6-main"
       gpu-arch-type: cuda
-      gpu-arch-version: "12.1"
+      gpu-arch-version: "12.6"
       timeout: 60
       script: |
         echo "::group::Print machine info"
@@ -107,9 +107,9 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
       runner: linux.arm64.m7g.4xlarge
-      docker-image: "pytorch/manylinuxaarch64-builder:cuda12.1-main"
+      docker-image: "pytorch/manylinuxaarch64-builder:cuda12.6-main"
       gpu-arch-type: cuda
-      gpu-arch-version: "12.1"
+      gpu-arch-version: "12.6"
       timeout: 60
       script: |
         echo "::group::Print machine info"

--- a/.github/workflows/run-readme-pr-linuxaarch64.yml
+++ b/.github/workflows/run-readme-pr-linuxaarch64.yml
@@ -23,11 +23,6 @@ jobs:
         uname -a
         echo "::endgroup::"
 
-        echo "::group::Install newer objcopy that supports --set-section-alignment"
-        yum install -y  devtoolset-11-binutils
-        export PATH=/opt/rh/devtoolset-11/root/usr/bin/:$PATH
-        echo "::endgroup::"
-
         TORCHCHAT_DEVICE=cpu .ci/scripts/run-docs readme
 
         echo "::group::Completion"
@@ -67,11 +62,6 @@ jobs:
         uname -a
         echo "::endgroup::"
 
-        echo "::group::Install newer objcopy that supports --set-section-alignment"
-        yum install -y  devtoolset-10-binutils
-        export PATH=/opt/rh/devtoolset-10/root/usr/bin/:$PATH
-        echo "::endgroup::"
-
         TORCHCHAT_DEVICE=cpu .ci/scripts/run-docs gguf
 
         echo "::group::Completion"
@@ -94,11 +84,6 @@ jobs:
         uname -a
         echo "::endgroup::"
 
-        echo "::group::Install newer objcopy that supports --set-section-alignment"
-        yum install -y  devtoolset-10-binutils
-        export PATH=/opt/rh/devtoolset-10/root/usr/bin/:$PATH
-        echo "::endgroup::"
-
         TORCHCHAT_DEVICE=cpu .ci/scripts/run-docs advanced
 
         echo "::group::Completion"
@@ -119,11 +104,6 @@ jobs:
       script: |
         echo "::group::Print machine info"
         uname -a
-        echo "::endgroup::"
-
-        echo "::group::Install newer objcopy that supports --set-section-alignment"
-        yum install -y  devtoolset-10-binutils
-        export PATH=/opt/rh/devtoolset-10/root/usr/bin/:$PATH
         echo "::endgroup::"
 
         TORCHCHAT_DEVICE=cpu .ci/scripts/run-docs evaluation

--- a/.github/workflows/run-readme-pr-linuxaarch64.yml
+++ b/.github/workflows/run-readme-pr-linuxaarch64.yml
@@ -24,8 +24,8 @@ jobs:
         echo "::endgroup::"
 
         echo "::group::Install newer objcopy that supports --set-section-alignment"
-        yum install -y  devtoolset-10-binutils
-        export PATH=/opt/rh/devtoolset-10/root/usr/bin/:$PATH
+        yum install -y  devtoolset-11-binutils
+        export PATH=/opt/rh/devtoolset-11/root/usr/bin/:$PATH
         echo "::endgroup::"
 
         TORCHCHAT_DEVICE=cpu .ci/scripts/run-docs readme

--- a/.github/workflows/run-readme-pr-linuxaarch64.yml
+++ b/.github/workflows/run-readme-pr-linuxaarch64.yml
@@ -12,6 +12,7 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
       runner: linux.arm64.m7g.4xlarge
+      docker-image: "pytorch/manylinuxaarch64-builder:cuda12.1-main"
       gpu-arch-type: cuda
       gpu-arch-version: "12.1"
       timeout: 60
@@ -36,6 +37,7 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
       runner: linux.arm64.m7g.4xlarge
+      docker-image: "pytorch/manylinuxaarch64-builder:cuda12.1-main"
       gpu-arch-type: cuda
       gpu-arch-version: "12.1"
       timeout: 60
@@ -55,6 +57,7 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
       runner: linux.arm64.m7g.4xlarge
+      docker-image: "pytorch/manylinuxaarch64-builder:cuda12.1-main"
       gpu-arch-type: cuda
       gpu-arch-version: "12.1"
       timeout: 60
@@ -79,6 +82,7 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
       runner: linux.arm64.m7g.4xlarge
+      docker-image: "pytorch/manylinuxaarch64-builder:cuda12.1-main"
       gpu-arch-type: cuda
       gpu-arch-version: "12.1"
       timeout: 60
@@ -103,6 +107,7 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
       runner: linux.arm64.m7g.4xlarge
+      docker-image: "pytorch/manylinuxaarch64-builder:cuda12.1-main"
       gpu-arch-type: cuda
       gpu-arch-version: "12.1"
       timeout: 60

--- a/.github/workflows/run-readme-pr-linuxaarch64.yml
+++ b/.github/workflows/run-readme-pr-linuxaarch64.yml
@@ -14,10 +14,9 @@ jobs:
       id-token: write
       contents: read
     with:
-      runner: linux.arm64.m7g.4xlarge
-      docker-image: "pytorch/manylinux2_28_aarch64-builder:cuda12.6"
-      gpu-arch-type: cuda-aarch64
-      gpu-arch-version: "12.6"
+      runner: linux.arm64.2xlarge
+      docker-image: "pytorch/manylinux2_28_aarch64-builder:cpu-aarch64-main"
+      gpu-arch-type: cpu-aarch64
       timeout: 60
       script: |
         echo "::group::Print machine info"
@@ -45,7 +44,6 @@ jobs:
       runner: linux.arm64.2xlarge
       docker-image: "pytorch/manylinux2_28_aarch64-builder:cpu-aarch64-main"
       gpu-arch-type: cpu-aarch64
-      gpu-arch-version: "12.6"
       timeout: 60
       script: |
         echo "::group::Print machine info"
@@ -61,11 +59,13 @@ jobs:
 
   test-gguf-cpu:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    permissions:
+      id-token: write
+      contents: read
     with:
       runner: linux.arm64.2xlarge
-      docker-image: "manylinuxaarch64-builder:cpu-aarch64-main"
+      docker-image: "pytorch/manylinux2_28_aarch64-builder:cpu-aarch64-main"
       gpu-arch-type: cpu-aarch64
-      gpu-arch-version: "12.6"
       timeout: 60
       script: |
         echo "::group::Print machine info"
@@ -86,11 +86,13 @@ jobs:
 
   test-advanced-cpu:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    permissions:
+      id-token: write
+      contents: read
     with:
-      runner: linux.arm64.m7g.4xlarge
-      docker-image: "pytorch/manylinuxaarch64-builder:cuda12.6-main"
-      gpu-arch-type: cuda-aarch64
-      gpu-arch-version: "12.6"
+      runner: linux.arm64.2xlarge
+      docker-image: "pytorch/manylinux2_28_aarch64-builder:cpu-aarch64-main"
+      gpu-arch-type: cpu-aarch64
       timeout: 60
       script: |
         echo "::group::Print machine info"
@@ -111,11 +113,13 @@ jobs:
 
   test-evaluation-cpu:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    permissions:
+      id-token: write
+      contents: read
     with:
-      runner: linux.arm64.m7g.4xlarge
-      docker-image: "pytorch/manylinuxaarch64-builder:cuda12.6-main"
-      gpu-arch-type: cuda-aarch64
-      gpu-arch-version: "12.6"
+      runner: linux.arm64.2xlarge
+      docker-image: "pytorch/manylinux2_28_aarch64-builder:cpu-aarch64-main"
+      gpu-arch-type: cpu-aarch64
       timeout: 60
       script: |
         echo "::group::Print machine info"

--- a/.github/workflows/run-readme-pr-linuxaarch64.yml
+++ b/.github/workflows/run-readme-pr-linuxaarch64.yml
@@ -11,7 +11,7 @@ jobs:
   test-readme-cpu:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
-      runner: linux-aarch64
+      runner: linux.arm64.2xlarge
       gpu-arch-type: cuda
       gpu-arch-version: "12.1"
       timeout: 60
@@ -35,7 +35,7 @@ jobs:
   test-quantization-cpu:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
-      runner: linux-aarch64
+      runner: linux.arm64.2xlarge
       gpu-arch-type: cuda
       gpu-arch-version: "12.1"
       timeout: 60
@@ -54,7 +54,7 @@ jobs:
   test-gguf-cpu:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
-      runner: linux-aarch64
+      runner: linux.arm64.2xlarge
       gpu-arch-type: cuda
       gpu-arch-version: "12.1"
       timeout: 60
@@ -78,7 +78,7 @@ jobs:
   test-advanced-cpu:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
-      runner: linux-aarch64
+      runner: linux.arm64.2xlarge
       gpu-arch-type: cuda
       gpu-arch-version: "12.1"
       timeout: 60
@@ -102,7 +102,7 @@ jobs:
   test-evaluation-cpu:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
-      runner: linux-aarch64
+      runner: linux.arm64.2xlarge
       gpu-arch-type: cuda
       gpu-arch-version: "12.1"
       timeout: 60

--- a/.github/workflows/run-readme-pr-linuxaarch64.yml
+++ b/.github/workflows/run-readme-pr-linuxaarch64.yml
@@ -9,10 +9,10 @@ on:
 
 jobs:
   test-readme-cpu:
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       runner: linux.arm64.m7g.4xlarge
-      docker-image: "pytorch/manylinuxaarch64-builder:cuda12.6-main"
+      docker-image: "pytorch/manylinux2_28_aarch64-builder:cuda12.6"
       gpu-arch-type: cuda-aarch64
       gpu-arch-version: "12.6"
       timeout: 60
@@ -34,11 +34,11 @@ jobs:
         echo "::endgroup::"
 
   test-quantization-cpu:
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
-      runner: linux.arm64.m7g.4xlarge
-      docker-image: "pytorch/manylinuxaarch64-builder:cuda12.6-main"
-      gpu-arch-type: cuda-aarch64
+      runner: linux.arm64.2xlarge
+      docker-image: "pytorch/manylinux2_28_aarch64-builder:cpu-aarch64-main"
+      gpu-arch-type: cpu-aarch64
       gpu-arch-version: "12.6"
       timeout: 60
       script: |
@@ -56,9 +56,9 @@ jobs:
   test-gguf-cpu:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
-      runner: linux.arm64.m7g.4xlarge
-      docker-image: "pytorch/manylinuxaarch64-builder:cuda12.6-main"
-      gpu-arch-type: cuda-aarch64
+      runner: linux.arm64.2xlarge
+      docker-image: "manylinuxaarch64-builder:cpu-aarch64-main"
+      gpu-arch-type: cpu-aarch64
       gpu-arch-version: "12.6"
       timeout: 60
       script: |

--- a/.github/workflows/run-readme-pr-linuxaarch64.yml
+++ b/.github/workflows/run-readme-pr-linuxaarch64.yml
@@ -50,11 +50,6 @@ jobs:
         uname -a
         echo "::endgroup::"
 
-        echo "::group::Install newer objcopy that supports --set-section-alignment"
-        yum install -y  devtoolset-10-binutils
-        export PATH=/opt/rh/devtoolset-10/root/usr/bin/:$PATH
-        echo "::endgroup::"
-
         TORCHCHAT_DEVICE=cpu .ci/scripts/run-docs quantization
 
   test-gguf-cpu:


### PR DESCRIPTION
https://github.com/pytorch/torchchat/pull/1350 used `linux-aarch64` as the runner when we should be using `linux.arm64.2xlarge` for aarch64 instead