### PR TITLE
Update import of sdpa_with_kv_cache to custom_ops

### DIFF
--- a/torchchat/model.py
+++ b/torchchat/model.py
@@ -1025,7 +1025,7 @@ try:
     # For quantized_decomposed ops
     from executorch.kernels import quantized  # no-qa
     # For llama::sdpa_with_kv_cache.out, preprocess ops
-    from executorch.extension.llm.custom_ops import sdpa_with_kv_cache  # no-qa
+    from executorch.extension.llm.custom_ops import custom_ops  # no-qa
 
     class PTEModel(nn.Module):
         def __init__(self, config, path) -> None:


### PR DESCRIPTION
Picking up BC-breaking change from https://github.com/pytorch/executorch/pull/6996 that was pulled in https://github.com/pytorch/torchchat/pull/1459

https://github.com/pytorch/torchchat/pull/1459 missed a callsite resulting in test failures found in https://github.com/pytorch/torchchat/issues/1463