### PR TITLE
Typo: Fix generate signature type hint for attention_backend

### DIFF
--- a/torchchat/generate.py
+++ b/torchchat/generate.py
@@ -685,7 +685,7 @@ class LocalGenerator:
         sequential_prefill=True,
         callback=lambda x: x,
         max_seq_length: int,
-        attention_backend: str = "math",
+        attention_backend: SDPBackend = torch.nn.attention.SDPBackend.MATH,
         seed: Optional[int] = None,
         **sampling_kwargs,
     ) -> torch.Tensor:


### PR DESCRIPTION
`attention_backend` is a SDPBackend, not a string
Fixing typo from https://github.com/pytorch/torchchat/pull/1456

cc: @yanbing-j 