### PR TITLE
Decode_n_tokens yield eos/eot token

### DIFF
--- a/torchchat/generate.py
+++ b/torchchat/generate.py
@@ -576,6 +576,7 @@ class LocalGenerator:
                         **sampling_kwargs,
                     )
                     input_pos += 1
+                    yield cur_token.clone(), next_prob.clone()
                     break
 
         if not encountered_eos:


### PR DESCRIPTION
Seems like we should yield the `cur_token`/`next_token` when it's an eos or eot so that it is included in the `generator_func` in `chat`. Also this way `start_pos` is incremented to an empty position in the cache. Repro similar to #1462, although there is no visible response degradation. 

I've pushed logs from my trace (https://github.com/nlpfollower/torchchat/pull/2). You can see how without this yield the first id in the `input_pos` at the beginning of a round overlaps, and overwrites, the last cache entry made in the previous turn.