### PR TITLE
Added support for Multimodal eval

### DIFF
--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -34,4 +34,4 @@ streamlit
 flask
 
 # eval
-lm_eval==0.4.2
+lm_eval==0.4.5

--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -34,4 +34,4 @@ streamlit
 flask
 
 # eval
-lm_eval==0.4.5
+lm_eval==0.4.7

--- a/torchchat/cli/builder.py
+++ b/torchchat/cli/builder.py
@@ -16,13 +16,22 @@ import torch._dynamo.config
 import torch._inductor.config
 import torch.distributed as dist
 
-from torchchat.distributed.utils import(
+from torchtune.models.convert_weights import meta_to_tune
+
+from torchtune.models.llama3_1._position_embeddings import Llama3ScaledRoPE
+
+from torchtune.models.llama3_2_vision._convert_weights import llama3_vision_meta_to_tune
+
+from torchtune.training import set_default_dtype
+
+from torchchat.distributed.logging_utils import SingletonLogger
+
+from torchchat.distributed.utils import (
     Color as color,
     CUDATrackTime,
-    init_distributed,
     GPUMemoryMonitor,
+    init_distributed,
 )
-from torchchat.distributed.logging_utils import SingletonLogger
 
 from torchchat.model import Model, ModelArgs, ModelType, Transformer, TransformerArgs
 from torchchat.model_config.model_config import resolve_model_config
@@ -34,15 +43,6 @@ from torchchat.utils.build_utils import (
 )
 from torchchat.utils.measure_time import measure_time
 from torchchat.utils.quantize import quantize_model
-
-
-from torchtune.models.convert_weights import meta_to_tune
-
-from torchtune.models.llama3_1._position_embeddings import Llama3ScaledRoPE
-
-from torchtune.models.llama3_2_vision._convert_weights import llama3_vision_meta_to_tune
-
-from torchtune.training import set_default_dtype
 
 
 @dataclass
@@ -190,15 +190,19 @@ class BuilderArgs:
         tp = getattr(args, "tp", 1)
         chpt_from = getattr(args, "chpt_from", "hf")
         sdp_backend_dict = {
-            'math': torch.nn.attention.SDPBackend.MATH,
-            'flash_attention': torch.nn.attention.SDPBackend.FLASH_ATTENTION,
-            'efficient_attention': torch.nn.attention.SDPBackend.EFFICIENT_ATTENTION,
-            'cudnn_attention': torch.nn.attention.SDPBackend.CUDNN_ATTENTION,
+            "math": torch.nn.attention.SDPBackend.MATH,
+            "flash_attention": torch.nn.attention.SDPBackend.FLASH_ATTENTION,
+            "efficient_attention": torch.nn.attention.SDPBackend.EFFICIENT_ATTENTION,
+            "cudnn_attention": torch.nn.attention.SDPBackend.CUDNN_ATTENTION,
         }
         attention_backend = sdp_backend_dict[args.attention_backend]
-        if args.device == "cpu" and (args.attention_backend == "efficient_attention"
-                                     or args.attention_backend == "cudnn_attention"):
-            print(f"Warning: {args.attention_backend} is not supported on CPU. Using math instead.")
+        if args.device == "cpu" and (
+            args.attention_backend == "efficient_attention"
+            or args.attention_backend == "cudnn_attention"
+        ):
+            print(
+                f"Warning: {args.attention_backend} is not supported on CPU. Using math instead."
+            )
             attention_backend = torch.nn.attention.SDPBackend.MATH
         return cls(
             checkpoint_dir=checkpoint_dir,
@@ -316,7 +320,17 @@ class TokenizerArgs:
         if model is None:
             return
 
-        if sum([self.is_tiktoken, self.is_hf_tokenizer, self.is_sentencepiece, self.is_llama_3_2_mm]) != 1:
+        if (
+            sum(
+                [
+                    self.is_tiktoken,
+                    self.is_hf_tokenizer,
+                    self.is_sentencepiece,
+                    self.is_llama_3_2_mm,
+                ]
+            )
+            != 1
+        ):
             raise RuntimeError(f"no tokenizer was found at {self.tokenizer_path}")
 
         is_tiktoken = self.is_tiktoken
@@ -328,10 +342,10 @@ class TokenizerArgs:
         use_hf_tokenizer = model.config.use_hf_tokenizer
         use_other_tokenizer = not (use_tiktoken or use_hf_tokenizer)
         if (
-            (is_tiktoken and not use_tiktoken) or
-            (is_hf_tokenizer and not use_hf_tokenizer) or
-            (is_sentencepiece and not use_other_tokenizer) or
-            (is_llama_3_2_mm and not use_other_tokenizer)
+            (is_tiktoken and not use_tiktoken)
+            or (is_hf_tokenizer and not use_hf_tokenizer)
+            or (is_sentencepiece and not use_other_tokenizer)
+            or (is_llama_3_2_mm and not use_other_tokenizer)
         ):
             raise RuntimeError(
                 "model-specified tokenizer ({}) does not match provided tokenizer ({}) for {}".format(
@@ -529,6 +543,7 @@ def _load_model(builder_args: BuilderArgs) -> Model:
         # AOTI-compoiled model will load its own weights.
         # Release weights here to avoid OOM
         import gc
+
         if hasattr(model, "model"):
             model.model = None
         gc.collect()
@@ -586,6 +601,7 @@ def _initialize_model(
 
             def do_nothing(max_batch_size, max_seq_length):
                 pass
+
             model.setup_caches = do_nothing
 
             model.forward = torch._export.aot_load(
@@ -623,6 +639,7 @@ def _initialize_model(
 
             def do_nothing(max_batch_size, max_seq_length):
                 pass
+
             model.setup_caches = do_nothing
 
             model.forward = aoti_compiled_model
@@ -669,7 +686,9 @@ def _initialize_model(
         logger = SingletonLogger.get_logger()
 
         gpu_memory_monitor = GPUMemoryMonitor("cuda")
-        logger.info(f"{color.yellow} {gpu_memory_monitor.get_device_info()}{color.reset}")
+        logger.info(
+            f"{color.yellow} {gpu_memory_monitor.get_device_info()}{color.reset}"
+        )
 
         # Model-level config
         if builder_args.params_table:
@@ -680,20 +699,16 @@ def _initialize_model(
         config = TransformerArgs.from_params(model_config.transformer_args["text"])
         logger.info(f"Transformer Config: {config}")
 
-        #TODO: Move into head of file after solving circular import
-        from torchchat.distributed.checkpoint_utils import (
-            load_model_weights,
-            )
+        # TODO: Move into head of file after solving circular import
+        from torchchat.distributed.checkpoint_utils import load_model_weights
 
         # Validate pipeline degree
         assert config.n_layers % pp_degree == 0
 
         # Create device mesh
         device_mesh = dist.init_device_mesh(
-            "cuda",
-            (pp_degree, tp_degree),
-            mesh_dim_names=("pp", "tp")
-            )
+            "cuda", (pp_degree, tp_degree), mesh_dim_names=("pp", "tp")
+        )
         tp_mesh = device_mesh["tp"]
         pp_mesh = device_mesh["pp"]
         logger.info(f"Created device mesh: {device_mesh}\n{tp_mesh=}, {pp_mesh=}")
@@ -722,7 +737,13 @@ def _initialize_model(
         # Load weights
         logger.info(f"Loading weights for {pp_rank=} on {device=}")
         with CUDATrackTime() as timer:
-            load_model_weights(model, builder_args.distribution_path, device, config, builder_args.chpt_from)
+            load_model_weights(
+                model,
+                builder_args.distribution_path,
+                device,
+                config,
+                builder_args.chpt_from,
+            )
 
         logger.info(
             f"{color.green}Total weight loading time: {timer.get_time()} {timer.unit} for rank {rank}{color.reset}"
@@ -736,7 +757,7 @@ def _initialize_model(
         # lanes.
         # TODO: bump up the lane count
         pipeline_lanes = 1
-        seqlen_prefill=1024
+        seqlen_prefill = 1024
         with device:
             model.setup_caches(1, seqlen_prefill, cache_lanes=pipeline_lanes)
 

--- a/torchchat/cli/builder.py
+++ b/torchchat/cli/builder.py
@@ -70,6 +70,7 @@ class BuilderArgs:
     dynamic_shapes: bool = False
     max_seq_length: Optional[int] = None
     attention_backend: str = "math"
+    modality: Optional[str] = "text"
 
     def __post_init__(self):
         if self.device is None:
@@ -142,6 +143,10 @@ class BuilderArgs:
         dso_path = getattr(args, "dso_path", None)
         pte_path = getattr(args, "pte_path", None)
         aoti_package_path = getattr(args, "aoti_package_path", None)
+
+        modality = "text"
+        if args.modality:
+            modality = args.modality
 
         is_chat_model = False
         if args.is_chat_model:
@@ -217,6 +222,7 @@ class BuilderArgs:
             chpt_from=chpt_from,
             distribution_path=distribution_path,
             is_chat_model=is_chat_model,
+            modality=modality,
             dynamic_shapes=getattr(args, "dynamic_shapes", False),
             max_seq_length=getattr(args, "max_seq_length", None),
             attention_backend=attention_backend,

--- a/torchchat/cli/builder.py
+++ b/torchchat/cli/builder.py
@@ -247,13 +247,29 @@ class TokenizerArgs:
     is_sentencepiece: bool = False
     is_tiktoken: bool = False
     is_hf_tokenizer: bool = False
+    is_llama_3_2_mm: bool = False
     t: Optional[Any] = None
 
     def __post_init__(self):
+        # special handling for llama-3.2-mm
+        if "llama-3.2-11b-vision" in str(self.tokenizer_path).lower():
+            try:
+                from torchtune.models.llama3_2_vision import llama3_2_vision_transform
+
+                self.t = llama3_2_vision_transform(path=str(self.tokenizer_path))
+                self.is_llama_3_2_mm = True
+                self.is_tiktoken = False
+                self.is_sentencepiece = False
+                self.is_hf_tokenizer = False
+                return
+            except:
+                pass
+
         try:
             from tokenizer.tiktoken import Tokenizer as TiktokenTokenizer
 
             self.t = TiktokenTokenizer(model_path=str(self.tokenizer_path))
+            self.is_llama_3_2_mm = False
             self.is_tiktoken = True
             self.is_sentencepiece = False
             self.is_hf_tokenizer = False
@@ -265,6 +281,7 @@ class TokenizerArgs:
             from sentencepiece import SentencePieceProcessor
 
             self.t = SentencePieceProcessor(model_file=str(self.tokenizer_path))
+            self.is_llama_3_2_mm = False
             self.is_tiktoken = False
             self.is_sentencepiece = True
             self.is_hf_tokenizer = False
@@ -276,6 +293,7 @@ class TokenizerArgs:
             from tokenizer.hf_tokenizer import HFTokenizer
 
             self.t = HFTokenizer(str(self.tokenizer_path))
+            self.is_llama_3_2_mm = False
             self.is_tiktoken = False
             self.is_sentencepiece = False
             self.is_hf_tokenizer = True
@@ -283,6 +301,7 @@ class TokenizerArgs:
         except:
             pass
 
+        self.is_llama_3_2_mm = False
         self.is_tiktoken = False
         self.is_sentencepiece = False
         self.is_hf_tokenizer = False
@@ -297,20 +316,22 @@ class TokenizerArgs:
         if model is None:
             return
 
-        if sum([self.is_tiktoken, self.is_hf_tokenizer, self.is_sentencepiece]) != 1:
+        if sum([self.is_tiktoken, self.is_hf_tokenizer, self.is_sentencepiece, self.is_llama_3_2_mm]) != 1:
             raise RuntimeError(f"no tokenizer was found at {self.tokenizer_path}")
 
         is_tiktoken = self.is_tiktoken
         is_sentencepiece = self.is_sentencepiece
         is_hf_tokenizer = self.is_hf_tokenizer
+        is_llama_3_2_mm = self.is_llama_3_2_mm
+
         use_tiktoken = model.config.use_tiktoken
         use_hf_tokenizer = model.config.use_hf_tokenizer
-        use_sentencepiece = not (use_tiktoken or use_hf_tokenizer)
-
+        use_other_tokenizer = not (use_tiktoken or use_hf_tokenizer)
         if (
             (is_tiktoken and not use_tiktoken) or
             (is_hf_tokenizer and not use_hf_tokenizer) or
-            (is_sentencepiece and not use_sentencepiece)
+            (is_sentencepiece and not use_other_tokenizer) or
+            (is_llama_3_2_mm and not use_other_tokenizer)
         ):
             raise RuntimeError(
                 "model-specified tokenizer ({}) does not match provided tokenizer ({}) for {}".format(

--- a/torchchat/cli/cli.py
+++ b/torchchat/cli/cli.py
@@ -144,7 +144,6 @@ def _add_model_specification_args(parser) -> None:
         choices=["text", "text-image"],
         # help=argparse.SUPPRESS,
         help="Modality of the model. Options: text, text-image",
-        # help="Modality of the model. Options: text, text-image",
     )
 
 

--- a/torchchat/cli/cli.py
+++ b/torchchat/cli/cli.py
@@ -137,6 +137,16 @@ def _add_model_specification_args(parser) -> None:
         help=argparse.SUPPRESS,
     )
 
+    model_specification_parser.add_argument(
+        "--modality",
+        type=str,
+        default="text",
+        choices=["text", "text-image"],
+        # help=argparse.SUPPRESS,
+        help="Modality of the model. Options: text, text-image",
+        # help="Modality of the model. Options: text, text-image",
+    )
+
 
 # Add CLI Args related to model configuration (compilation, quant, etc)
 # Excludes compile args if subcommand is export

--- a/torchchat/model.py
+++ b/torchchat/model.py
@@ -608,6 +608,12 @@ class FlamingoModel(Model):
             decoder_max_seq_len=decoder_max_seq_len,
         )
 
+    def caches_are_setup(self) -> bool:
+        return self.model.caches_are_setup()
+
+    def caches_are_enabled(self) -> bool:
+        return self.model.caches_are_enabled()
+
     def reset_caches(self):
         self.model.reset_caches()
 

--- a/torchchat/model_params/Llama-3.2-11B-Vision.json
+++ b/torchchat/model_params/Llama-3.2-11B-Vision.json
@@ -1,6 +1,6 @@
 {
     "model_type": "flamingo",
-    "use_tiktoken": true,
+    "use_tiktoken": false,
     "encoder": {
         "patch_size": 14,
         "num_heads": 16,

--- a/torchchat/usages/eval.py
+++ b/torchchat/usages/eval.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 import argparse
-from typing import Callable, Optional
+from typing import Callable, Optional, Dict, List
 
 import torch
 import torch._dynamo.config
@@ -33,6 +33,21 @@ import lm_eval
 from lm_eval.evaluator import evaluate
 from lm_eval.models.huggingface import HFLM as eval_wrapper
 from lm_eval.tasks import get_task_dict
+from lm_eval.models.hf_vlms import HFMultimodalLM
+from lm_eval.evaluator import evaluate
+
+from torchtune.modules.model_fusion import DeepFusionModel
+from torchtune.modules.transforms import Transform
+from torchtune.data import (
+    format_content_with_images,
+    left_pad_sequence,
+    Message,
+    padded_collate_tiled_images_and_mask,
+)
+from torchtune.generation import generate, sample
+from torchtune import utils
+
+import PIL
 
 
 def setup_cache_padded_seq_input_pos_max_seq_length_for_prefill(
@@ -89,7 +104,7 @@ class GPTFastEvalWrapper(eval_wrapper):
         device="cpu",
         is_pte_model: bool = False,
     ):
-        super().__init__(device=device)
+        super().__init__(pretrained="gpt2", device=device)
         self._model = model
         self._model_forward = (
             model_forward
@@ -168,6 +183,250 @@ class GPTFastEvalWrapper(eval_wrapper):
         raise Exception("unimplemented")
 
 
+# Dummy class which _VLMEvalWrapper can inherit from when the imports don't work
+# class HFMultimodalLM():
+#     def __init__(self):
+#         return
+
+class _VLMEvalWrapper(HFMultimodalLM):
+    """An EvalWrapper for EleutherAI's eval harness based on gpt-fast's
+    EvalWrapper: https://github.com/pytorch-labs/gpt-fast/blob/main/eval.py.
+
+    Note:
+        This is ONLY for vision-language models.
+
+    Args:
+        model (DeepFusionModel): The VLM to evaluate.
+        transform (Transform): The transform (tokenizer) to use for preprocessing.
+        device (torch.device): The device to use.
+        max_seq_length (int): The maximum sequence length.
+        batch_size (int): The batch size.
+        dtype (torch.dtype): dtype for the model caches during generation.
+        enable_kv_cache (bool): Whether to enable KV cache for generation.
+        image_tag (str): The string to use for the image token. Default is "<image>", which
+            is the default used by the MMMU dataset.
+        max_images_per_sample (int): The maximum number of images per sample. Defaults to
+            the max number of images in MMMU.
+    """
+
+    def __init__(
+        self,
+        model: DeepFusionModel,
+        transform: Transform,
+        *,
+        device: torch.device,
+        max_seq_length: int = 4096,
+        batch_size: int = 8,
+        dtype: torch.dtype = torch.bfloat16,
+        enable_kv_cache: bool = True,
+        # TODO (@joecummings): Update these defaults once more multimodal
+        # tasks are added to the eval harness
+        image_tag: str = "<image>",
+        max_images_per_sample: int = 7,
+    ):
+        self._model = model
+        self._transform = transform
+        self._device = device
+        self._max_seq_length = max_seq_length
+        self._batch_size = batch_size
+        self._dtype = dtype
+        # Defaulting KV cache to True for multimodal
+        self._enable_kv_cache = True
+        self._image_tag = image_tag
+        self._max_images_per_sample = max_images_per_sample
+
+    @property
+    def model(self):
+        # Not actually changing the dtype here, just adding it as a
+        # property on the model
+        self._model.dtype = self._dtype
+        return self._model
+
+    @property
+    def model_transform(self):
+        return self._transform
+
+    @property
+    def device(self):
+        return self._device
+
+    @property
+    def cache_hook(self):
+        # Dummy class to appease the Harness
+        class DummyCacheHook:
+            def __init__(self):
+                self.add_partial = lambda x, y, z: True
+
+        return DummyCacheHook()
+
+    @property
+    def rank(self):
+        # Hardcoded for now b/c we only support single GPU eval
+        return 0
+
+    @property
+    def world_size(self):
+        # Hardcoded for now b/c we only support single GPU eval
+        return 1
+
+    @property
+    def batch_size(self):
+        return self._batch_size
+
+    @property
+    def eos_token_id(self):
+        return self._transform.tokenizer.eos_id
+
+    @property
+    def eot_token_id(self):
+        return self._transform.tokenizer.eot_id
+
+    @property
+    def max_length(self):
+        return self._max_seq_length
+
+    @property
+    def truncation(self):
+        return True
+
+    def tok_encode(self, string, **kwargs) -> List[int]:
+        # This is only used to get a number of tokens for use in sorting samples in dataset
+        # These values will not actually be used for eval
+        return self._transform.tokenizer.encode(string, add_bos=False, add_eos=False)
+
+    def tok_decode(self, tokens, skip_special_tokens=True) -> str:
+        if isinstance(tokens, int):
+            tokens = [tokens]
+        return self._transform.tokenizer.decode(
+            tokens, skip_special_tokens=skip_special_tokens
+        )
+
+    def tok_batch_multimodal_encode(
+        self,
+        all_texts: List[str],
+        all_images: List[List[PIL.Image.Image]],
+        left_truncate_len: int = None,
+        *args,
+        **kwargs,
+    ):
+        # Eleuther already parses out the text and images, so we just need to get
+        # it into a Message format for our tokenizer
+        all_encoded_messages = []
+
+        for text, images in zip(all_texts, all_images):
+            # Ensure images are all RGB
+            proper_images = []
+            for image in images:
+                if image.mode != "RGB":
+                    image = image.convert("RGB")
+                proper_images.append(image)
+
+            # Construct the messages
+            messages = []
+            content = format_content_with_images(
+                text, image_tag=self._image_tag, images=proper_images
+            )
+            messages.append(Message(role="user", content=content))
+            messages.append(Message(role="assistant", content=""))
+
+            # Transform the messages
+            tok_batch = self.model_transform({"messages": messages}, inference=True)
+            all_encoded_messages.append(tok_batch)
+
+        # Pad the encoded messages
+        tok_batch = padded_collate_tiled_images_and_mask(
+            all_encoded_messages,
+            pad_direction="left",
+            pad_max_images=self._max_images_per_sample,
+        )
+        utils.batch_to_device(tok_batch, self.device)
+
+        # Convert the batch to the format expected by the HF
+        tok_batch["input_ids"] = tok_batch.pop("tokens")
+
+        # the harness will use left_truncate_len to indicate that the current batch
+        # needs to be truncated to self.max_seq_len - self.max_gen_toks
+        if left_truncate_len is not None:
+            tok_batch["input_ids"] = tok_batch["input_ids"][:, -left_truncate_len:]
+
+        return tok_batch
+
+    @torch.inference_mode()
+    def _model_multimodal_generate(
+        self,
+        batch: Dict[str, torch.Tensor],
+        max_length: int,
+        stop: List[str],
+        **generation_kwargs,
+    ):
+        # 1. Validate inputs
+        prompt = batch.pop("input_ids")
+        bsz, seq_len = prompt.shape
+
+        temperature = generation_kwargs.get("temperature", 0.0)
+        do_sample = generation_kwargs.get("do_sample", False)
+        if do_sample or temperature != 0.0:
+            raise RuntimeError(
+                "Any decoding strategy other than greedy is not supported."
+            )
+
+        if bsz > 1:
+            raise ValueError(
+                f"Got a batch size of '{bsz}'. Batch size > 1 is not yet supported for "
+                "multimodal generation."
+            )
+
+        # 2. Setup KV cache and masks for bsz 1
+        with self.device:
+            if self.model.caches_are_enabled():
+                self.model.reset_caches()
+            else:
+                self.model.setup_caches(
+                    batch_size=1,
+                    dtype=self._dtype,
+                    encoder_max_seq_len=self.model_transform.image_seq_len
+                    * self._max_images_per_sample,
+                    decoder_max_seq_len=self.max_length,
+                )
+            causal_mask = torch.tril(
+                torch.ones(
+                    size=(self.max_length, self.max_length),
+                    dtype=torch.bool,
+                )
+            )
+            input_pos = torch.arange(self.max_length)
+
+        batch["input_pos"] = input_pos[None, :seq_len]
+        batch["mask"] = causal_mask[None, :seq_len]
+
+        # 3. Prefill step
+        generated_tokens = []
+        logits = self.model(prompt, **batch)[:, -1]
+        token = sample(logits, temperature=0.0, top_k=None)
+        generated_tokens.append(token.item())
+
+        cache_mask = batch["encoder_mask"][:, -1:]
+
+        # 4. Continue generating
+        for _ in range(max_length):
+            if token.item() in self.model_transform.stop_tokens:
+                break
+            logits = self.model(
+                token,
+                mask=causal_mask[None, seq_len, None, :],
+                encoder_input=None,
+                encoder_mask=cache_mask,
+                input_pos=input_pos[None, seq_len],
+            )[:, -1]
+            token = sample(logits, temperature=0.0, top_k=None)
+            generated_tokens.append(token.item())
+            seq_len += 1
+
+        # 5. Return generated tokens
+        return torch.tensor(generated_tokens, dtype=torch.int32).unsqueeze(0)
+
+
+
 @torch.no_grad()
 def eval(
     model: Model,
@@ -223,6 +482,54 @@ def eval(
     return eval_results
 
 
+def multi_model_eval(
+    model: Model,
+    model_forward: Callable,
+    tokenizer,
+    tasks: Optional[list] = None,
+    limit: Optional[int] = None,
+    max_seq_length: Optional[int] = None,
+    device: str = "cpu",
+    is_pte_model: bool = False,):
+    """
+    Evaluates a language model on a specified task using the lm-evaluation-harness library.
+
+    Args:
+        model (Model): The pre-trained language model to evaluate.
+        tokenizer: The tokenizer to use for encoding/decoding text.
+        tasks (Optional[list]): The names of the evaluation tasks to perform.
+        limit (Optional[int]): The maximum number of samples to evaluate (None for all available).
+        max_seq_length (Optional[int]): The maximum sequence length allowed for input text.
+
+    Returns:
+        eval_results (dict): A dictionary of evaluation results for the specified task(s).
+    """
+    if tasks is None:
+        tasks = ["wikitext"]
+
+    model_eval_wrapper = _VLMEvalWrapper(
+        model,
+        transform=tokenizer, # tranform is the tokenizer for multimodal models
+        max_seq_length=max_seq_length,
+        device=device,
+    )
+
+    try:
+        lm_eval.tasks.initialize_tasks()
+    except:
+        pass
+
+    task_dict = get_task_dict(tasks)
+
+    eval_results = evaluate(
+        model_eval_wrapper,
+        task_dict,
+        limit=limit,
+    )
+    eval_results["times"] = model_eval_wrapper.times
+    return eval_results
+
+
 def main(args) -> None:
     """Evaluates model on a task from the `lm-evaluation-harness` library.
 
@@ -243,6 +550,10 @@ def main(args) -> None:
     limit = args.limit
     compile = args.compile
     max_seq_length = args.max_seq_length
+
+    modality = builder_args.modality
+    print(f"Modality of model={modality}")
+    assert modality in ["text", "text-image"], "Only text and text-plus-image modality is supported for evaluation"
 
     print(f"Using device={device}")
     set_precision(builder_args.precision)
@@ -267,8 +578,16 @@ def main(args) -> None:
         )
         torch._inductor.config.coordinate_descent_tuning = False if device == "cpu" else True
 
+    evaluator = None
+    if modality == "text":
+        evaluator = eval
+    elif modality == "text-image":
+        evaluator = multi_model_eval
+    else:
+        raise ValueError(f"Unsupported modality: {modality}")
+
     with measure_time("Time to run eval: {time:.02f}s."):
-        result = eval(
+        result = evaluator(
             model.to(device),
             model_forward,
             tokenizer,

--- a/torchchat/usages/eval.py
+++ b/torchchat/usages/eval.py
@@ -212,7 +212,7 @@ class VLMEvalWrapper(HFMultimodalLM):
         *,
         device: torch.device,
         max_seq_length: int = 4096,
-        batch_size: int = 8,
+        batch_size: int = 1,
         dtype: torch.dtype = torch.bfloat16,
         enable_kv_cache: bool = True,
         # TODO (@joecummings): Update these defaults once more multimodal


### PR DESCRIPTION
PR for https://github.com/pytorch/torchchat/issues/1334

Used [VLMEvalWrapper](https://github.com/pytorch/torchtune/blob/2128559bd182daf3aa056a7cceefcfc135460b0f/recipes/eleuther_eval.py#L40) from torchtune to support evaluation for multimodal models (llama3.2 11b only for now)

A sample run for mmmu_val_art:
```
(venv) anirudhsingh@Anirudhs-MacBook-Pro-4 torchchat % python torchchat.py eval Llama-3.2-mm --device cpu --dtype bf16 --task mmmu_val_art --modality text-image --max-seq-length 2048 
NumExpr defaulting to 12 threads.
PyTorch version 2.7.0.dev20250124 available.
Looking for libcustom_ops_aot_lib.so in /Users/anirudhsingh/MISC/playground/torchchat/venv/lib/python3.10/site-packages/executorch
Loading custom ops library: /Users/anirudhsingh/MISC/playground/torchchat/venv/lib/python3.10/site-packages/executorch/extension/llm/custom_ops/libcustom_ops_aot_lib.dylib
Unable to import torchao experimental quant_api with error:  [Errno 2] No such file or directory: '/Users/anirudhsingh/MISC/playground/torchchat/torchao-build/src/ao/torchao/experimental/quant_api.py'
Modality of model=text-image
Using device=cpu
Loading model...
Time to load model: 0.25 seconds
-----------------------------------------------------------
Building contexts for mmmu_val_art on rank 0...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:00<00:00, 20148.78it/s]
Running generate_until requests
Running generate_until requests with text+image input: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [7:49:19<00:00, 938.65s/it]
Time to run eval: 28171.31s.
Time in model.forward: 28154.47s, over 30 model evaluations
forward run time stats - Median: 360.38s Min: 355.40s Max: 8932.57s
For model /Users/anirudhsingh/.torchchat/model-cache/meta-llama/Llama-3.2-11B-Vision-Instruct/model.pth
mmmu_val_art:
 alias: Art
 acc,none: 0.2333
 acc_stderr,none: 0.0785
```

And with a limit of 1 sample:
```
(venv) anirudhsingh@Anirudhs-MacBook-Pro-4 torchchat % python torchchat.py eval Llama-3.2-mm --device cpu --dtype bf16 --task mmmu_val_art --limit 1 --modality text-image --max-seq-length 720
NumExpr defaulting to 12 threads.
PyTorch version 2.7.0.dev20250124 available.
Looking for libcustom_ops_aot_lib.so in /Users/anirudhsingh/MISC/playground/torchchat/venv/lib/python3.10/site-packages/executorch
Loading custom ops library: /Users/anirudhsingh/MISC/playground/torchchat/venv/lib/python3.10/site-packages/executorch/extension/llm/custom_ops/libcustom_ops_aot_lib.dylib
Unable to import torchao experimental quant_api with error:  [Errno 2] No such file or directory: '/Users/anirudhsingh/MISC/playground/torchchat/torchao-build/src/ao/torchao/experimental/quant_api.py'
Modality of model=text-image
Using device=cpu
Loading model...
Time to load model: 0.25 seconds
-----------------------------------------------------------
Building contexts for mmmu_val_art on rank 0...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 5159.05it/s]
Running generate_until requests
Running generate_until requests with text+image input: 100%|██████████████████████████████████████████████████████████████| 1/1 [08:38<00:00, 518.97s/it]
Time to run eval: 531.16s.
Time in model.forward: 518.80s, over 1 model evaluations
forward run time stats - Median: 518.80s Min: 518.80s Max: 518.80s
For model /Users/anirudhsingh/.torchchat/model-cache/meta-llama/Llama-3.2-11B-Vision-Instruct/model.pth
mmmu_val_art:
 alias: Art
 acc,none: 0.0000
```
