### PR TITLE
Fix install ET without pybind

### DIFF
--- a/torchchat/utils/scripts/install_et.sh
+++ b/torchchat/utils/scripts/install_et.sh
@@ -5,7 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-set -ex pipefail
+set -exo pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")/install_utils.sh"
 

--- a/torchchat/utils/scripts/install_utils.sh
+++ b/torchchat/utils/scripts/install_utils.sh
@@ -5,7 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-set -ex pipefail
+set -exo pipefail
 
 if [ -z "$TORCHCHAT_ROOT" ]; then
   # Get the absolute path of the current script


### PR DESCRIPTION
Fix bash script, this prevents us from passing `false` to `ENABLE_ET_PYBIND`.
Example cmd:
`./torchchat/utils/scripts/install_et.sh false`