### PR TITLE
Restrict CMake < 4.0.0: BC breaking version release

### DIFF
--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -23,7 +23,7 @@ openai
 
 # Build tools
 wheel
-cmake>=3.24
+cmake>=3.24, < 4.0.0  # 4.0 is BC breaking
 ninja
 zstd
 


### PR DESCRIPTION
Release on March 27th: https://pypi.org/project/cmake/4.0.0/