### PR TITLE
Add Initial unit test example: Model_Config

### DIFF
--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -27,6 +27,9 @@ cmake>=3.24, < 4.0.0  # 4.0 is BC breaking
 ninja
 zstd
 
+# Test tools
+pytest
+
 # Browser mode
 streamlit
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    model_config: Tests related to model config

--- a/torchchat/model_config/tests/test_model_config.py
+++ b/torchchat/model_config/tests/test_model_config.py
@@ -1,0 +1,24 @@
+import pytest
+from torchchat.model_config.model_config import load_model_configs, resolve_model_config
+
+
+TEST_CONFIG = "meta-llama/llama-3.2-11b-vision"
+TEST_CONFIG_NAME = "meta-llama/Llama-3.2-11B-Vision"
+
+
+@pytest.mark.model_config
+def test_load_model_configs():
+    configs = load_model_configs()
+    assert TEST_CONFIG in configs
+    assert configs[TEST_CONFIG].name == TEST_CONFIG_NAME
+
+
+@pytest.mark.model_config
+def test_resolve_model_config():
+    config = resolve_model_config(TEST_CONFIG)
+    print(config)
+    assert config.name == TEST_CONFIG_NAME
+    assert config.checkpoint_file == "model.pth"
+
+    with pytest.raises(ValueError):
+        resolve_model_config("UnknownModel")


### PR DESCRIPTION
Add pytest to install requirements and an example test based on model_config
* Instructions and CI integration will be in following PRs

`pytest -m model_config`