### PR TITLE
[PyProject] Spin up an initial pyproject.toml allowing for local pip install

### DIFF
--- a/install/install_requirements.sh
+++ b/install/install_requirements.sh
@@ -44,96 +44,13 @@ fi
 
 echo "Using pip executable: $PIP_EXECUTABLE"
 
-# Since torchchat often uses main-branch features of pytorch, only the nightly
-# pip versions will have the required features. The PYTORCH_NIGHTLY_VERSION value should
-# agree with the third-party/pytorch pinned submodule commit.
-#
-# NOTE: If a newly-fetched version of the executorch repo changes the value of
-# PYTORCH_NIGHTLY_VERSION, you should re-run this script to install the necessary
-# package versions.
-PYTORCH_NIGHTLY_VERSION=dev20250327
-
-# Nightly version for torchvision
-VISION_NIGHTLY_VERSION=dev20250327
-
-# Nightly version for torchtune
-TUNE_NIGHTLY_VERSION=dev20250327
-
-# The pip repository that hosts nightly torch packages. cpu by default.
-# If cuda is available, based on presence of nvidia-smi, install the pytorch nightly
-# with cuda for faster execution on cuda GPUs.
-if [[ -x "$(command -v nvidia-smi)" ]];
-then
-  TORCH_NIGHTLY_URL="https://download.pytorch.org/whl/nightly/cu126"
-elif [[ -x "$(command -v rocminfo)" ]];
-then
-  TORCH_NIGHTLY_URL="https://download.pytorch.org/whl/nightly/rocm6.2"
-elif [[ -x "$(command -v xpu-smi)" ]];
-then
-  TORCH_NIGHTLY_URL="https://download.pytorch.org/whl/nightly/xpu"
-else
-  TORCH_NIGHTLY_URL="https://download.pytorch.org/whl/nightly/cpu"
-fi
-
-# pip packages needed by exir.
-if [[ -x "$(command -v xpu-smi)" ]];
-then
-  REQUIREMENTS_TO_INSTALL=(
-    torch=="2.8.0.${PYTORCH_NIGHTLY_VERSION}"
-    torchvision=="0.22.0.${VISION_NIGHTLY_VERSION}"
-    #torchtune=="0.7.0" # no 0.6.0 on xpu nightly
-  )
-else
-  REQUIREMENTS_TO_INSTALL=(
-    torch=="2.8.0.${PYTORCH_NIGHTLY_VERSION}"
-    torchvision=="0.22.0.${VISION_NIGHTLY_VERSION}"
-    torchtune=="0.7.0.${TUNE_NIGHTLY_VERSION}"
-  )
-fi
-
-#
-# First install requirements in install/requirements.txt. Older torch may be
-# installed from the dependency of other models. It will be overridden by
-# newer version of torch nightly installed later in this script.
-#
 (
   set -x
-  $PIP_EXECUTABLE install -r install/requirements.txt --extra-index-url "${TORCH_NIGHTLY_URL}"
+  $PIP_EXECUTABLE install -r install/requirements.txt
 )
 
-# Uninstall triton, as nightly will depend on pytorch-triton, which is one and the same
-(
-  set -x
-  $PIP_EXECUTABLE uninstall -y triton
-)
+bash install/install_torch.sh
 
-# Install the requirements. --extra-index-url tells pip to look for package
-# versions on the provided URL if they aren't available on the default URL.
-(
-  set -x
-  $PIP_EXECUTABLE install --extra-index-url "${TORCH_NIGHTLY_URL}" \
-    "${REQUIREMENTS_TO_INSTALL[@]}"
-)
-
-# Temporatory instal torchtune nightly from cpu nightly link since no torchtune nightly for xpu now
-# TODO: Change to install torchtune from xpu nightly link, once torchtune xpu nightly is ready
-if [[ -x "$(command -v xpu-smi)" ]];
-then
-(
-  set -x
-  $PIP_EXECUTABLE install --extra-index-url  "https://download.pytorch.org/whl/nightly/cpu" \
-    torchtune=="0.6.0.${TUNE_NIGHTLY_VERSION}"
-)
-fi
-
-bash install/install_torchao.sh
-
-if [[ -x "$(command -v nvidia-smi)" ]]; then
-  (
-    set -x
-    $PYTHON_EXECUTABLE torchchat/utils/scripts/patch_triton.py
-  )
-fi
 (
   set -x
   $PIP_EXECUTABLE install evaluate=="0.4.3" lm-eval=="0.4.7" psutil=="6.0.0"

--- a/install/install_torch.sh
+++ b/install/install_torch.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+if [ -z "${PYTHON_EXECUTABLE:-}" ];
+then
+  if [[ -z ${CONDA_DEFAULT_ENV:-} ]] || [[ ${CONDA_DEFAULT_ENV:-} == "base" ]] || [[ ! -x "$(command -v python)" ]];
+  then
+    PYTHON_EXECUTABLE=python3
+  else
+    PYTHON_EXECUTABLE=python
+  fi
+fi
+echo "Using python executable: $PYTHON_EXECUTABLE"
+
+if [[ "$PYTHON_EXECUTABLE" == "python" ]];
+then
+  PIP_EXECUTABLE=pip
+elif [[ "$PYTHON_EXECUTABLE" == "python3" ]];
+then
+  PIP_EXECUTABLE=pip3
+else
+  PIP_EXECUTABLE=pip${PYTHON_SYS_VERSION}
+fi
+echo "Using pip executable: $PIP_EXECUTABLE"
+
+# Since torchchat often uses main-branch features of pytorch, only the nightly
+# pip versions will have the required features. The PYTORCH_NIGHTLY_VERSION value should
+# agree with the third-party/pytorch pinned submodule commit.
+#
+# NOTE: If a newly-fetched version of the executorch repo changes the value of
+# PYTORCH_NIGHTLY_VERSION, you should re-run this script to install the necessary
+# package versions.
+PYTORCH_NIGHTLY_VERSION=dev20250327
+
+# Nightly version for torchvision
+VISION_NIGHTLY_VERSION=dev20250327
+
+# Nightly version for torchtune
+TUNE_NIGHTLY_VERSION=dev20250327
+
+# The pip repository that hosts nightly torch packages. cpu by default.
+# If cuda is available, based on presence of nvidia-smi, install the pytorch nightly
+# with cuda for faster execution on cuda GPUs.
+if [[ -x "$(command -v nvidia-smi)" ]];
+then
+  TORCH_NIGHTLY_URL="https://download.pytorch.org/whl/nightly/cu126"
+elif [[ -x "$(command -v rocminfo)" ]];
+then
+  TORCH_NIGHTLY_URL="https://download.pytorch.org/whl/nightly/rocm6.2"
+elif [[ -x "$(command -v xpu-smi)" ]];
+then
+  TORCH_NIGHTLY_URL="https://download.pytorch.org/whl/nightly/xpu"
+else
+  TORCH_NIGHTLY_URL="https://download.pytorch.org/whl/nightly/cpu"
+fi
+
+# pip packages needed by exir.
+if [[ -x "$(command -v xpu-smi)" ]];
+then
+  REQUIREMENTS_TO_INSTALL=(
+    torch=="2.8.0.${PYTORCH_NIGHTLY_VERSION}"
+    torchvision=="0.22.0.${VISION_NIGHTLY_VERSION}"
+    #torchtune=="0.7.0" # no 0.6.0 on xpu nightly
+  )
+else
+  REQUIREMENTS_TO_INSTALL=(
+    torch=="2.8.0.${PYTORCH_NIGHTLY_VERSION}"
+    torchvision=="0.22.0.${VISION_NIGHTLY_VERSION}"
+    torchtune=="0.7.0.${TUNE_NIGHTLY_VERSION}"
+  )
+fi
+
+# Uninstall triton, as nightly will depend on pytorch-triton, which is one and the same
+(
+  set -x
+  $PIP_EXECUTABLE uninstall -y triton
+)
+
+# Install the requirements. --extra-index-url tells pip to look for package
+# versions on the provided URL if they aren't available on the default URL.
+(
+  set -x
+  $PIP_EXECUTABLE install --extra-index-url "${TORCH_NIGHTLY_URL}" \
+    "${REQUIREMENTS_TO_INSTALL[@]}"
+)
+
+# Temporatory instal torchtune nightly from cpu nightly link since no torchtune nightly for xpu now
+# TODO: Change to install torchtune from xpu nightly link, once torchtune xpu nightly is ready
+if [[ -x "$(command -v xpu-smi)" ]];
+then
+(
+  set -x
+  $PIP_EXECUTABLE install --extra-index-url  "https://download.pytorch.org/whl/nightly/cpu" \
+    torchtune=="0.6.0.${TUNE_NIGHTLY_VERSION}"
+)
+fi
+
+bash install/install_torchao.sh
+
+# Delete since already patched in PT main
+if [[ -x "$(command -v nvidia-smi)" ]]; then
+  (
+    set -x
+    $PYTHON_EXECUTABLE torchchat/utils/scripts/patch_triton.py
+  )
+fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -12,25 +12,29 @@ authors = [
 license = { file = "LICENSE" }
 keywords = ["pytorch", "machine learning", "llm"]
 readme = "README.md"
-requires-python = ">=3.10"
 
-[project.dependencies]
-huggingface_hub = "*"
-gguf = "*"
-tiktoken = "*"
-tokenizers = "*"
-jinja2 = "*"
-snakeviz = "*"
-sentencepiece = "*"
-numpy = ">=1.17"
-blobfile = "*"
-tomli = { version = ">=1.1.0", markers = "python_version < '3.11'" }
-openai = "*"
-wheel = "*"
-cmake = ">=3.24, <4.0.0"
-ninja = "*"
-zstd = "*"
-pytest = "*"
-streamlit = "*"
-flask = "*"
-lm_eval = "==0.4.7"
+requires-python = ">=3.10"
+dependencies=[
+  "huggingface_hub",
+  "gguf",
+  "tiktoken",
+  "tokenizers",
+  "jinja2",
+  "snakeviz",
+  "sentencepiece",
+  "numpy>=1.17",
+  "blobfile",
+  "tomli>=1.1.0; python_version < '3.11'",
+  "openai",
+  "wheel",
+  "cmake>=3.24,<4.0.0",
+  "ninja",
+  "zstd",
+  "pytest",
+  "streamlit",
+  "flask",
+  "lm-eval==0.4.7",
+]
+
+[tool.setuptools]
+packages = ["torchchat"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,24 +15,43 @@ readme = "README.md"
 
 requires-python = ">=3.10"
 dependencies=[
+  # Hugging Face downloads
   "huggingface_hub",
+
+  # GGUF import
   "gguf",
+
+  # Tiktoken tokenizer for Llama 3 and other advanced models
   "tiktoken",
+
+  # Tokenizers and jinja2 for other non-llama models that use HF tokenizers
   "tokenizers",
   "jinja2",
+
+  # Miscellaneous
   "snakeviz",
   "sentencepiece",
   "numpy>=1.17",
   "blobfile",
   "tomli>=1.1.0; python_version < '3.11'",
   "openai",
+
+  # Build tools
   "wheel",
   "cmake>=3.24,<4.0.0",
   "ninja",
   "zstd",
+
+  # Test tools
   "pytest",
+
+  # Browser mode
   "streamlit",
+
+  # Server mode
   "flask",
+
+  # eval
   "lm-eval==0.4.7",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "torchchat"
+version = "0.1.0"
+description = "PyTorch showcase for running LLMs on local devices"
+authors = [
+  {name="PyTorch Team", email="packages@pytorch.org"},
+]
+license = { file = "LICENSE" }
+keywords = ["pytorch", "machine learning", "llm"]
+readme = "README.md"
+requires-python = ">=3.10"
+
+[project.dependencies]
+huggingface_hub = "*"
+gguf = "*"
+tiktoken = "*"
+tokenizers = "*"
+jinja2 = "*"
+snakeviz = "*"
+sentencepiece = "*"
+numpy = ">=1.17"
+blobfile = "*"
+tomli = { version = ">=1.1.0", markers = "python_version < '3.11'" }
+openai = "*"
+wheel = "*"
+cmake = ">=3.24, <4.0.0"
+ninja = "*"
+zstd = "*"
+pytest = "*"
+streamlit = "*"
+flask = "*"
+lm_eval = "==0.4.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,12 +33,12 @@ dependencies=[
   "sentencepiece",
   "numpy>=1.17",
   "blobfile",
-  "tomli>=1.1.0; python_version < '3.11'",
+  "tomli>=1.1.0; python_version<'3.11'",
   "openai",
 
   # Build tools
   "wheel",
-  "cmake>=3.24,<4.0.0",
+  "cmake>=3.24,<4.0.0", # 4.0 is BC breaking
   "ninja",
   "zstd",
 


### PR DESCRIPTION
This is the first step towards pip-installing of torchchat. Specifically this PR:
* Adds a pyproject.toml based on `requirements.txt`
* Pulls `torch` installation instructions from `install_requirements.sh` into `install_torch.sh`
  * `torch` installation will be done separately from pip install

Note that install instructions have not changed pending refactoring the [following](https://github.com/pytorch/torchchat/pull/1528) from `install_requirements.sh`
```
(
  set -x
  $PIP_EXECUTABLE install evaluate=="0.4.3" lm-eval=="0.4.7" psutil=="6.0.0"
)
```


---
Testing:
```
# Original
./install/install_requirements.sh; pip freeze > original.txt

# New Install Requirements
./install/install_requirements.sh; pip freeze > new.txt

> diff original.txt new.txt 
None
```