### PR TITLE
Removing redundant installs from install_requirements.sh

### DIFF
--- a/install/install_requirements.sh
+++ b/install/install_requirements.sh
@@ -134,7 +134,3 @@ if [[ -x "$(command -v nvidia-smi)" ]]; then
     $PYTHON_EXECUTABLE torchchat/utils/scripts/patch_triton.py
   )
 fi
-(
-  set -x
-  $PIP_EXECUTABLE install evaluate=="0.4.3" lm-eval=="0.4.7" psutil=="6.0.0"
-)


### PR DESCRIPTION
These imports were introduced to work around an old import bug, but is no longer required; they get picked up either directly or indirectly from requirements.txt