### PR TITLE
mps compile: Bump PT pin to April 18th

### DIFF
--- a/install/install_torch.sh
+++ b/install/install_torch.sh
@@ -34,13 +34,13 @@ echo "Using pip executable: $PIP_EXECUTABLE"
 # NOTE: If a newly-fetched version of the executorch repo changes the value of
 # PYTORCH_NIGHTLY_VERSION, you should re-run this script to install the necessary
 # package versions.
-PYTORCH_NIGHTLY_VERSION=dev20250417
+PYTORCH_NIGHTLY_VERSION=dev20250418
 
 # Nightly version for torchvision
-VISION_NIGHTLY_VERSION=dev20250417
+VISION_NIGHTLY_VERSION=dev20250418
 
 # Nightly version for torchtune
-TUNE_NIGHTLY_VERSION=dev20250417
+TUNE_NIGHTLY_VERSION=dev20250418
 
 # The pip repository that hosts nightly torch packages. cpu by default.
 # If cuda is available, based on presence of nvidia-smi, install the pytorch nightly


### PR DESCRIPTION
PR [#150661](https://github.com/pytorch/pytorch/pull/150661) fixed issue [#150629](https://github.com/pytorch/pytorch/issues/150629). We need to bump the torch pin by one day, since [#150661](https://github.com/pytorch/pytorch/pull/150661) was included in the April 18th nightly.



