### PR TITLE
Simplify `TokenizerArgs.__post_init__` with Enum Tokenizer Type

### DIFF
--- a/torchchat/export.py
+++ b/torchchat/export.py
@@ -482,7 +482,7 @@ def main(args):
 
     if tokenizer_args is None:
         tokenizer_type = "0"
-    elif tokenizer_args.is_sentencepiece:
+    elif tokenizer_args.is_sentencepiece():
         tokenizer_type = "2"  # Corresponding to llama2
     else:
         tokenizer_type = "3"  # Corresponding to llama3

--- a/torchchat/generate.py
+++ b/torchchat/generate.py
@@ -365,14 +365,14 @@ class LocalGenerator:
         # must use tiktokenizer.
         # Piggy backing off of this flag then for now to identify llama3
         # without prompting user.
-        self.is_llama3_model = self.tokenizer_args.is_tiktoken
+        self.is_llama3_model = self.tokenizer_args.is_tiktoken()
         if self.is_llama3_model:
             self.chat_formatter = Llama3ChatFormatter(self.tokenizer)
             if generator_args.chat_mode:
                 logger.debug(
                     "Llama3 model detected in chat mode. Using updated sentence schemas"
                 )
-        elif self.tokenizer_args.is_hf_tokenizer:
+        elif self.tokenizer_args.is_hf_tokenizer():
             if not self.tokenizer.has_chat_template():
                 raise ValueError("Tokenizer must have a chat template")
             self.chat_formatter = HFTokenizerChatFormatter(self.tokenizer)


### PR DESCRIPTION
Summary:
Simplify `TokenizerArgs.__post_init__` with enum tokenizer type, since only one of the tokenizer type can be true.

We want to touch as less code outside of `__post_init__` as possible at the moment.

Test Plan:
python torchchat.py generate llama2|llama3|granite-code

Reviewers:
@Jack-Khuu

Subscribers:

Issue:
https://github.com/pytorch/torchchat/issues/1518