### PR TITLE
Move imports to prepare for making torchtune an optional dependency

### DIFF
--- a/torchchat/cli/builder.py
+++ b/torchchat/cli/builder.py
@@ -37,15 +37,6 @@ from torchchat.utils.measure_time import measure_time
 from torchchat.utils.quantize import quantize_model
 
 
-from torchtune.models.convert_weights import meta_to_tune
-
-from torchtune.models.llama3_1._position_embeddings import Llama3ScaledRoPE
-
-from torchtune.models.llama3_2_vision._convert_weights import llama3_vision_meta_to_tune
-
-from torchtune.training import set_default_dtype
-
-
 @dataclass
 class BuilderArgs:
     checkpoint_path: Optional[Union[Path, str]] = None
@@ -416,6 +407,8 @@ def _load_model_gguf(builder_args: BuilderArgs) -> Model:
 
 
 def _load_checkpoint(builder_args: BuilderArgs):
+    from torchtune.models.convert_weights import meta_to_tune
+
     if builder_args.params_table and builder_args.params_table.endswith("Tune"):
         print("Loading Tune checkpoint")
         meta_checkpoint = torch.load(
@@ -458,6 +451,10 @@ def _load_checkpoint(builder_args: BuilderArgs):
 
 
 def _load_model_default(builder_args: BuilderArgs) -> Model:
+    from torchtune.models.llama3_1._position_embeddings import Llama3ScaledRoPE
+    from torchtune.models.llama3_2_vision._convert_weights import llama3_vision_meta_to_tune
+    from torchtune.training import set_default_dtype
+
     assert not builder_args.gguf_path
 
     model: Model = _init_model_on_meta_device(builder_args)

--- a/torchchat/cli/builder.py
+++ b/torchchat/cli/builder.py
@@ -414,9 +414,8 @@ def _load_model_gguf(builder_args: BuilderArgs) -> Model:
 
 
 def _load_checkpoint(builder_args: BuilderArgs):
-    from torchtune.models.convert_weights import meta_to_tune
-
     if builder_args.params_table and builder_args.params_table.endswith("Tune"):
+        from torchtune.models.convert_weights import meta_to_tune
         print("Loading Tune checkpoint")
         meta_checkpoint = torch.load(
             str(builder_args.checkpoint_path), mmap=True, weights_only=True
@@ -458,12 +457,6 @@ def _load_checkpoint(builder_args: BuilderArgs):
 
 
 def _load_model_default(builder_args: BuilderArgs) -> Model:
-    from torchtune.models.llama3_1._position_embeddings import Llama3ScaledRoPE
-    from torchtune.models.llama3_2_vision._convert_weights import (
-        llama3_vision_meta_to_tune,
-    )
-    from torchtune.training import set_default_dtype
-
     assert not builder_args.gguf_path
 
     model: Model = _init_model_on_meta_device(builder_args)
@@ -475,6 +468,11 @@ def _load_model_default(builder_args: BuilderArgs) -> Model:
         checkpoint = checkpoint["model"]
 
     if model.config.model_type == ModelType.Flamingo:
+        from torchtune.models.llama3_1._position_embeddings import Llama3ScaledRoPE
+        from torchtune.models.llama3_2_vision._convert_weights import (
+            llama3_vision_meta_to_tune,
+        )
+        from torchtune.training import set_default_dtype
         # TODO: Refactor this. For now, overwrite the model with model loaded from params_path
         with (
             set_default_dtype(builder_args.precision),

--- a/torchchat/cli/builder.py
+++ b/torchchat/cli/builder.py
@@ -17,13 +17,14 @@ import torch._dynamo.config
 import torch._inductor.config
 import torch.distributed as dist
 
-from torchchat.distributed.utils import(
+from torchchat.distributed.logging_utils import SingletonLogger
+
+from torchchat.distributed.utils import (
     Color as color,
     CUDATrackTime,
-    init_distributed,
     GPUMemoryMonitor,
+    init_distributed,
 )
-from torchchat.distributed.logging_utils import SingletonLogger
 
 from torchchat.model import Model, ModelArgs, ModelType, Transformer, TransformerArgs
 from torchchat.model_config.model_config import resolve_model_config
@@ -179,15 +180,19 @@ class BuilderArgs:
         tp = getattr(args, "tp", 1)
         chpt_from = getattr(args, "chpt_from", "hf")
         sdp_backend_dict = {
-            'math': torch.nn.attention.SDPBackend.MATH,
-            'flash_attention': torch.nn.attention.SDPBackend.FLASH_ATTENTION,
-            'efficient_attention': torch.nn.attention.SDPBackend.EFFICIENT_ATTENTION,
-            'cudnn_attention': torch.nn.attention.SDPBackend.CUDNN_ATTENTION,
+            "math": torch.nn.attention.SDPBackend.MATH,
+            "flash_attention": torch.nn.attention.SDPBackend.FLASH_ATTENTION,
+            "efficient_attention": torch.nn.attention.SDPBackend.EFFICIENT_ATTENTION,
+            "cudnn_attention": torch.nn.attention.SDPBackend.CUDNN_ATTENTION,
         }
         attention_backend = sdp_backend_dict[args.attention_backend]
-        if args.device == "cpu" and (args.attention_backend == "efficient_attention"
-                                     or args.attention_backend == "cudnn_attention"):
-            print(f"Warning: {args.attention_backend} is not supported on CPU. Using math instead.")
+        if args.device == "cpu" and (
+            args.attention_backend == "efficient_attention"
+            or args.attention_backend == "cudnn_attention"
+        ):
+            print(
+                f"Warning: {args.attention_backend} is not supported on CPU. Using math instead."
+            )
             attention_backend = torch.nn.attention.SDPBackend.MATH
         return cls(
             checkpoint_dir=checkpoint_dir,
@@ -229,11 +234,13 @@ class BuilderArgs:
         speculative_builder_args.pte_path = None
         return speculative_builder_args
 
+
 class TokenizerType(Enum):
     NONE = 0
     TIKTOKEN = 1
     SENTENCEPIECE = 2
     HF_TOKENIZER = 3
+
 
 @dataclass
 class TokenizerArgs:
@@ -298,9 +305,9 @@ class TokenizerArgs:
         use_sentencepiece = not (use_tiktoken or use_hf_tokenizer)
 
         if (
-            (is_tiktoken and not use_tiktoken) or
-            (is_hf_tokenizer and not use_hf_tokenizer) or
-            (is_sentencepiece and not use_sentencepiece)
+            (is_tiktoken and not use_tiktoken)
+            or (is_hf_tokenizer and not use_hf_tokenizer)
+            or (is_sentencepiece and not use_sentencepiece)
         ):
             raise RuntimeError(
                 "model-specified tokenizer ({}) does not match provided tokenizer ({}) for {}".format(
@@ -452,7 +459,9 @@ def _load_checkpoint(builder_args: BuilderArgs):
 
 def _load_model_default(builder_args: BuilderArgs) -> Model:
     from torchtune.models.llama3_1._position_embeddings import Llama3ScaledRoPE
-    from torchtune.models.llama3_2_vision._convert_weights import llama3_vision_meta_to_tune
+    from torchtune.models.llama3_2_vision._convert_weights import (
+        llama3_vision_meta_to_tune,
+    )
     from torchtune.training import set_default_dtype
 
     assert not builder_args.gguf_path
@@ -467,8 +476,9 @@ def _load_model_default(builder_args: BuilderArgs) -> Model:
 
     if model.config.model_type == ModelType.Flamingo:
         # TODO: Refactor this. For now, overwrite the model with model loaded from params_path
-        with set_default_dtype(builder_args.precision), torch.device(
-            builder_args.device
+        with (
+            set_default_dtype(builder_args.precision),
+            torch.device(builder_args.device),
         ):
             # It doubles the model size the memory, with redundancies of the initialized weights.
             # model = Model.from_params(builder_args.params_path)
@@ -504,6 +514,7 @@ def _load_model(builder_args: BuilderArgs) -> Model:
         # AOTI-compoiled model will load its own weights.
         # Release weights here to avoid OOM
         import gc
+
         if hasattr(model, "model"):
             model.model = None
         gc.collect()
@@ -561,6 +572,7 @@ def _initialize_model(
 
             def do_nothing(max_batch_size, max_seq_length):
                 pass
+
             model.setup_caches = do_nothing
 
             model.forward = torch._export.aot_load(
@@ -598,6 +610,7 @@ def _initialize_model(
 
             def do_nothing(max_batch_size, max_seq_length):
                 pass
+
             model.setup_caches = do_nothing
 
             model.forward = aoti_compiled_model
@@ -649,12 +662,15 @@ def _initialize_model(
         try:
             model = torch.load(builder_args.snapshot_path, weights_only=False)
         except Exception:
-            raise RuntimeError(f"Failed to load torchchat snapshot {builder_args.snapshot_path}")
+            raise RuntimeError(
+                f"Failed to load torchchat snapshot {builder_args.snapshot_path}"
+            )
         # _active_backend() does not allow DSO & AOTI to be true.
         # Choose either.
         from torchchat.utils.build_utils import set_backend
-        set_backend (dso=True, pte=False, aoti_package=False)
-        if (model.config != config):
+
+        set_backend(dso=True, pte=False, aoti_package=False)
+        if model.config != config:
             raise RuntimeError("loaded model architecture mismatch")
         ##
         ## import all libraries with custom kernels ans custom operators
@@ -672,7 +688,9 @@ def _initialize_model(
         logger = SingletonLogger.get_logger()
 
         gpu_memory_monitor = GPUMemoryMonitor("cuda")
-        logger.info(f"{color.yellow} {gpu_memory_monitor.get_device_info()}{color.reset}")
+        logger.info(
+            f"{color.yellow} {gpu_memory_monitor.get_device_info()}{color.reset}"
+        )
 
         # Model-level config
         if builder_args.params_table:
@@ -683,20 +701,16 @@ def _initialize_model(
         config = TransformerArgs.from_params(model_config.transformer_args["text"])
         logger.info(f"Transformer Config: {config}")
 
-        #TODO: Move into head of file after solving circular import
-        from torchchat.distributed.checkpoint_utils import (
-            load_model_weights,
-            )
+        # TODO: Move into head of file after solving circular import
+        from torchchat.distributed.checkpoint_utils import load_model_weights
 
         # Validate pipeline degree
         assert config.n_layers % pp_degree == 0
 
         # Create device mesh
         device_mesh = dist.init_device_mesh(
-            "cuda",
-            (pp_degree, tp_degree),
-            mesh_dim_names=("pp", "tp")
-            )
+            "cuda", (pp_degree, tp_degree), mesh_dim_names=("pp", "tp")
+        )
         tp_mesh = device_mesh["tp"]
         pp_mesh = device_mesh["pp"]
         logger.info(f"Created device mesh: {device_mesh}\n{tp_mesh=}, {pp_mesh=}")
@@ -725,7 +739,13 @@ def _initialize_model(
         # Load weights
         logger.info(f"Loading weights for {pp_rank=} on {device=}")
         with CUDATrackTime() as timer:
-            load_model_weights(model, builder_args.distribution_path, device, config, builder_args.chpt_from)
+            load_model_weights(
+                model,
+                builder_args.distribution_path,
+                device,
+                config,
+                builder_args.chpt_from,
+            )
 
         logger.info(
             f"{color.green}Total weight loading time: {timer.get_time()} {timer.unit} for rank {rank}{color.reset}"
@@ -739,7 +759,7 @@ def _initialize_model(
         # lanes.
         # TODO: bump up the lane count
         pipeline_lanes = 1
-        seqlen_prefill=1024
+        seqlen_prefill = 1024
         with device:
             model.setup_caches(1, seqlen_prefill, cache_lanes=pipeline_lanes)
 

--- a/torchchat/generate.py
+++ b/torchchat/generate.py
@@ -30,14 +30,6 @@ from torch._C import _SDPBackend as SDPBackend
 
 from PIL import Image
 
-# torchtune model definition dependencies
-from torchtune.data import Message, padded_collate_tiled_images_and_mask
-
-from torchtune.generation import sample as tune_sample
-
-from torchtune.models.llama3_2_vision._model_builders import llama3_2_vision_transform
-from torchtune.training import set_default_dtype
-
 from torchchat.cli.builder import (
     _initialize_model,
     _initialize_tokenizer,
@@ -450,6 +442,8 @@ class LocalGenerator:
         sequential_prefill=True,
         **sampling_kwargs,
     ) -> torch.Tensor:
+        from torchtune.generation import sample as tune_sample
+
         logger.debug("x: %s, input_pos: %s", x, input_pos)
         width = x.size(1)
         assert input_pos.size(0) == width
@@ -870,6 +864,11 @@ class LocalGenerator:
         max_new_tokens: Optional[int] = None,
         max_seq_len: Optional[int] = 2048,
     ) -> Tuple[torch.Tensor, Optional[Dict[str, Any]]]:
+        # torchtune model definition dependencies
+        from torchtune.data import Message, padded_collate_tiled_images_and_mask
+        from torchtune.models.llama3_2_vision._model_builders import llama3_2_vision_transform
+        from torchtune.training import set_default_dtype
+
         """
         Convert prompt and image prompts into consumable model input args.
 

--- a/torchchat/generate.py
+++ b/torchchat/generate.py
@@ -446,13 +446,12 @@ class LocalGenerator:
         sequential_prefill=True,
         **sampling_kwargs,
     ) -> torch.Tensor:
-        from torchtune.generation import sample as tune_sample
-
         logger.debug("x: %s, input_pos: %s", x, input_pos)
         width = x.size(1)
         assert input_pos.size(0) == width
 
         if self.model.config.model_type == ModelType.Flamingo:
+            from torchtune.generation import sample as tune_sample
             assert batch is not None, "Flamingo requires batch"
 
             # TODO: Verify sequential prefill works with multimodal models

--- a/torchchat/model.py
+++ b/torchchat/model.py
@@ -8,13 +8,13 @@ import logging
 import os
 import warnings
 from abc import ABC, abstractmethod
+from collections.abc import Hashable
 
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 
 from typing import Any, Callable, Dict, Optional, Union
-from collections.abc import Hashable
 
 import torch
 import torch.nn as nn
@@ -59,7 +59,6 @@ def identity(**kwargs):
     return list(kwargs.values())[0]
 
 
-
 class MultiModalProjector(nn.Module):
     def __init__(self, in_channels: int, out_channels: int, act: nn.Module):
         super().__init__()
@@ -97,9 +96,9 @@ class ConcateFusion(nn.Module):
         self.decoder.__setattr__(token_embedding_name, None)
 
         self.mm_projector = MultiModalProjector(
-                in_channels=mm_proj_in_channels,
-                out_channels=mm_proj_out_channels,
-                act=mm_proj_activation,
+            in_channels=mm_proj_in_channels,
+            out_channels=mm_proj_out_channels,
+            act=mm_proj_activation,
         )
 
     def forward(
@@ -206,7 +205,10 @@ class ModelRecipe:
 
     @classmethod
     def _llama3_1(cls):
-        from torchtune.models.llama3_1._component_builders import llama3_1 as llama3_1_builder
+        from torchtune.models.llama3_1._component_builders import (
+            llama3_1 as llama3_1_builder,
+        )
+
         return cls(
             model_type=ModelType.Llama3_1,
             modules={"text": llama3_1_builder},
@@ -225,7 +227,7 @@ class ModelRecipe:
             model_type=ModelType.Flamingo,
             modules={
                 "encoder": llama3_2_vision_encoder,
-                "decoder": llama3_2_vision_decoder
+                "decoder": llama3_2_vision_decoder,
             },
             fusion_class=DeepFusionModel,
         )
@@ -233,12 +235,10 @@ class ModelRecipe:
     @classmethod
     def _llava(cls):
         from torchtune.models.clip import clip_vision_encoder
+
         return cls(
             model_type=ModelType.Llava,
-            modules={
-                'encoder': clip_vision_encoder,
-                'decoder': Transformer
-            },
+            modules={"encoder": clip_vision_encoder, "decoder": Transformer},
             fusion_class=ConcateFusion,
         )
 
@@ -506,6 +506,7 @@ class Model(ABC, nn.Module):
         # TODO: Remove it once we can make fusion model configurable in model_param.
         try:
             from torchtune.modules.model_fusion import DeepFusionModel
+
             if recipe.fusion_class == DeepFusionModel:
                 modules["encoder_trainable"] = False
                 modules["decoder_trainable"] = False
@@ -633,7 +634,12 @@ class LlavaModel(Model):
         post_tokens: Optional[Tensor] = None,
         input_pos: Optional[Tensor] = None,
     ) -> Tensor:
-        return self.model(tokens, encoder_input=encoder_input, post_tokens=post_tokens, input_pos=input_pos)
+        return self.model(
+            tokens,
+            encoder_input=encoder_input,
+            post_tokens=post_tokens,
+            input_pos=input_pos,
+        )
 
     def setup_caches(self, max_batch_size, max_seq_length):
         self.model.setup_caches(max_batch_size, max_seq_length)
@@ -684,7 +690,9 @@ class Transformer(nn.Module):
     def load_hook(self, state_dict, prefix, *args):
         """Handle tied embeddings at load time"""
         if self.config.tie_word_embeddings:
-            state_dict.setdefault("model.output.weight", state_dict["model.tok_embeddings.weight"])
+            state_dict.setdefault(
+                "model.output.weight", state_dict["model.tok_embeddings.weight"]
+            )
 
     def setup_caches(self, max_batch_size, max_seq_length, cache_lanes: int = 1):
         if (
@@ -733,7 +741,9 @@ class Transformer(nn.Module):
                 ColwiseParallel(output_layouts=Replicate()),
             )
 
-    def forward(self, x: Tensor, input_pos: Optional[Tensor] = None, cache_lane: int = 0) -> Tensor:
+    def forward(
+        self, x: Tensor, input_pos: Optional[Tensor] = None, cache_lane: int = 0
+    ) -> Tensor:
         assert self.freqs_cis is not None, "Caches must be initialized first"
         mask = self.causal_mask[None, None, input_pos]
         freqs_cis = self.freqs_cis[input_pos]
@@ -777,11 +787,24 @@ class TransformerBlock(nn.Module):
         self.feed_forward.distribute(device_mesh)
 
     def forward(
-        self, x: Tensor, input_pos: Tensor, freqs_cis: Tensor, mask: Tensor, cache_lane: int = 0
+        self,
+        x: Tensor,
+        input_pos: Tensor,
+        freqs_cis: Tensor,
+        mask: Tensor,
+        cache_lane: int = 0,
     ) -> Tensor:
-        h = x + self.attention(
-            self.attention_norm(x), freqs_cis, mask, input_pos, cache_lane=cache_lane
-        ) * self.residual_multiplier
+        h = (
+            x
+            + self.attention(
+                self.attention_norm(x),
+                freqs_cis,
+                mask,
+                input_pos,
+                cache_lane=cache_lane,
+            )
+            * self.residual_multiplier
+        )
         out = h + self.feed_forward(self.ffn_norm(h)) * self.residual_multiplier
         return out
 
@@ -794,12 +817,18 @@ class Attention(nn.Module):
         # key, query, value projections for all heads, but in a batch
         # total_head_dim = (config.n_heads + 2 * config.n_local_heads) * config.head_dim
         # self.wqkv = nn.Linear(config.dim, total_head_dim, bias=config.attention_bias)
-        self.wq = nn.Linear(config.dim, config.n_heads * config.head_dim, bias=config.attention_bias)
+        self.wq = nn.Linear(
+            config.dim, config.n_heads * config.head_dim, bias=config.attention_bias
+        )
         self.wk = nn.Linear(
-            config.dim, config.n_local_heads * config.head_dim, bias=config.attention_bias
+            config.dim,
+            config.n_local_heads * config.head_dim,
+            bias=config.attention_bias,
         )
         self.wv = nn.Linear(
-            config.dim, config.n_local_heads * config.head_dim, bias=config.attention_bias
+            config.dim,
+            config.n_local_heads * config.head_dim,
+            bias=config.attention_bias,
         )
 
         self.wo = nn.Linear(config.dim, config.dim, bias=config.attention_bias)
@@ -818,10 +847,12 @@ class Attention(nn.Module):
         if hasattr(self, "tp_degree"):
             n_local_heads = self.n_local_heads // self.tp_degree
 
-        self.kv_cache = nn.ModuleList([
-            KVCache(max_batch_size, max_seq_length, n_local_heads, self.head_dim)
-            for _ in range(cache_lanes)
-        ])
+        self.kv_cache = nn.ModuleList(
+            [
+                KVCache(max_batch_size, max_seq_length, n_local_heads, self.head_dim)
+                for _ in range(cache_lanes)
+            ]
+        )
 
     def load_hook(self, state_dict, prefix, *args):
         # if prefix + "wq.weight" in state_dict:
@@ -927,9 +958,15 @@ class Attention(nn.Module):
 class FeedForward(nn.Module):
     def __init__(self, config: TransformerArgs) -> None:
         super().__init__()
-        self.w1 = nn.Linear(config.dim, config.hidden_dim, bias=config.feed_forward_bias)
-        self.w2 = nn.Linear(config.hidden_dim, config.dim, bias=config.feed_forward_bias)
-        self.w3 = nn.Linear(config.dim, config.hidden_dim, bias=config.feed_forward_bias)
+        self.w1 = nn.Linear(
+            config.dim, config.hidden_dim, bias=config.feed_forward_bias
+        )
+        self.w2 = nn.Linear(
+            config.hidden_dim, config.dim, bias=config.feed_forward_bias
+        )
+        self.w3 = nn.Linear(
+            config.dim, config.hidden_dim, bias=config.feed_forward_bias
+        )
 
     def distribute(self, device_mesh: DeviceMesh):
         parallelize_module(self.w1, device_mesh, ColwiseParallel())
@@ -1017,13 +1054,13 @@ def apply_rotary_emb(x: Tensor, freqs_cis: Tensor) -> Tensor:
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 try:
+    # For llama::sdpa_with_kv_cache.out, preprocess ops
+    from executorch.extension.llm.custom_ops import custom_ops  # no-qa
     from executorch.extension.pybindings import portable_lib as exec_lib
 
     # ET changed the way it's loading the custom ops so it's not included in portable_lib but has to be loaded separately.
     # For quantized_decomposed ops
     from executorch.kernels import quantized  # no-qa
-    # For llama::sdpa_with_kv_cache.out, preprocess ops
-    from executorch.extension.llm.custom_ops import custom_ops  # no-qa
 
     class PTEModel(nn.Module):
         def __init__(self, config, path) -> None:
@@ -1031,7 +1068,9 @@ try:
             self.config = config
             self.model_ = exec_lib._load_for_executorch(str(path))
 
-            self.text_transformer_args = TransformerArgs.from_params(self.config.transformer_args["text"])
+            self.text_transformer_args = TransformerArgs.from_params(
+                self.config.transformer_args["text"]
+            )
             # TODO: attempt to use "get_max_seq_len" method on the model after
             # ExecuTorch bug is fixed.
             max_seq_len = 128

--- a/torchchat/usages/openai_api.py
+++ b/torchchat/usages/openai_api.py
@@ -19,10 +19,6 @@ import torch
 
 from PIL import Image
 
-from torchtune.data import Message, padded_collate_tiled_images_and_mask
-
-from torchtune.models.llama3_2_vision._model_builders import llama3_2_vision_transform
-
 from torchchat.cli.download import is_model_downloaded, load_model_configs
 from torchchat.generate import LocalGenerator, DistributedGenerator, GeneratorArgs
 from torchchat.model import FlamingoModel
@@ -304,7 +300,7 @@ class OpenAiApiGeneratorMixin:
 
     def _gen_model_inputs_from_openai_completion_request(
         self, completion_request: CompletionRequest
-    ) -> List[Message]:
+    ) -> List:
         """Generate model inputs from an OpenAI completion request.
 
         Args:

--- a/torchchat/usages/openai_api.py
+++ b/torchchat/usages/openai_api.py
@@ -13,14 +13,14 @@ from abc import ABC
 from dataclasses import dataclass
 from io import BytesIO
 from pwd import getpwuid
-from typing import Any, Dict, List, Optional, Union, Type
+from typing import Any, Dict, List, Optional, Type, Union
 
 import torch
 
 from PIL import Image
 
 from torchchat.cli.download import is_model_downloaded, load_model_configs
-from torchchat.generate import LocalGenerator, DistributedGenerator, GeneratorArgs
+from torchchat.generate import DistributedGenerator, GeneratorArgs, LocalGenerator
 from torchchat.model import FlamingoModel
 
 from torchchat.utils.build_utils import device_sync
@@ -388,7 +388,7 @@ class OpenAiApiGeneratorMixin:
         device_sync(device=self.builder_args.device)
 
         buffer = []
-        ILLEGAL_CHAR = '\ufffd'
+        ILLEGAL_CHAR = "\ufffd"
         # Process each token, metrics tuple yielded by Generator.generate.
         for y, _ in self.generate(
             model=self.model,
@@ -491,7 +491,14 @@ def create_openai_api_generator(distributed: bool) -> Type:
     """
 
     # Base class order matters to make sure OpenAiApiGeneratorMixin overrides methods in DistributedGenerator and Generator
-    return type('OpenAiApiGenerator', (OpenAiApiGeneratorMixin, DistributedGenerator if distributed else LocalGenerator), {})
+    return type(
+        "OpenAiApiGenerator",
+        (
+            OpenAiApiGeneratorMixin,
+            DistributedGenerator if distributed else LocalGenerator,
+        ),
+        {},
+    )
 
 
 """


### PR DESCRIPTION
`torchtune` now can be an optional dependency. In most of the cases, the import was just moved to a specific function or class. In the case of the `openai_api.py`, the better solution was to just remove the unused import and `Message` type hint, because it is not a real reason to have an import of an optional library in the class. 