### PR TITLE
Migrate to modern logger interface

### DIFF
--- a/torchchat/generate.py
+++ b/torchchat/generate.py
@@ -1389,7 +1389,7 @@ class DistributedGenerator(LocalGenerator):
         if builder_args.pp > 1:
             self.seqlen_prefill = 1024  # sequence length for prefill stage
 
-            logger.warn(
+            logger.warning(
                 f"{color.yellow}Pipeline parallelism is still experimental and might be slow{color.reset}"
             )
             pp_mesh = self.model.device_mesh["pp"]


### PR DESCRIPTION
## Description
The `logger.warn()` method is deprecated since Python2.7 and replaced with `logger.warning()`. It leads to those warnings:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```