### PR TITLE
[EZ] Replace `pytorch-labs` with `meta-pytorch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,7 +672,7 @@ awesome libraries and tools you've built around local LLM inference.
 * Christian Puhrsch, Horace He, Joe Isaacson and many more for their
   many contributions in Accelerating GenAI models in the *"Anything,
   Fast!"* pytorch.org blogs, and, in particular, Horace He for [GPT,
-  Fast!](https://github.com/pytorch-labs/gpt-fast), which we have
+  Fast!](https://github.com/meta-pytorch/gpt-fast), which we have
   directly adopted (both ideas and code) from his repo.
 
 

--- a/torchchat/usages/eval.py
+++ b/torchchat/usages/eval.py
@@ -178,7 +178,7 @@ class VLMEvalWrapper(HFMultimodalLM):
     -------------------------------------------------------------------------------
 
     An EvalWrapper for EleutherAI's eval harness based on gpt-fast's
-    EvalWrapper: https://github.com/pytorch-labs/gpt-fast/blob/main/eval.py.
+    EvalWrapper: https://github.com/meta-pytorch/gpt-fast/blob/main/eval.py.
 
     Note:
         This is ONLY for vision-language models.


### PR DESCRIPTION
This PR replaces all instances of `pytorch-labs` with `meta-pytorch` in this repository now that the `pytorch-labs` org has been renamed to `meta-pytorch`

## Changes Made
- Replaced all occurrences of `pytorch-labs` with `meta-pytorch`
- Only modified files with extensions: .py, .md, .sh, .rst, .cpp, .h, .txt, .yml
- Skipped binary files and files larger than 1MB due to GitHub api payload limits in the script to cover all repos in this org. Will do a more manual second pass later to cover any larger files

## Files Modified
This PR updates files that contained the target text.

Generated by automated script on 2025-08-12T20:58:02.375454+00:00Z