### PR TITLE
Change macOS runner version in workflow

### DIFF
--- a/.github/workflows/run-readme-pr-mps.yml
+++ b/.github/workflows/run-readme-pr-mps.yml
@@ -36,7 +36,7 @@ jobs:
   test-quantization-mps-macos:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
-      runner: macos-m1-14
+      runner: macos-14
       timeout: 60
       script: |
           set -x
@@ -64,7 +64,7 @@ jobs:
   test-gguf-mps-macos:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
-      runner: macos-m1-14  # needs MPS, was macos-m1-stable
+      runner: macos-14  # needs MPS, was macos-m1-stable
       script: |
           set -x
           conda create -y -n test-quantization-mps-macos python=3.10.11
@@ -91,7 +91,7 @@ jobs:
   test-advanced-mps-macos:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
-      runner: macos-m1-14  # needs MPS, was macos-m1-stable
+      runner: macos-14  # needs MPS, was macos-m1-stable
       script: |
           set -x
           conda create -y -n test-quantization-mps-macos python=3.10.11
@@ -118,7 +118,7 @@ jobs:
   test-evaluation-mps-macos:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
-      runner: macos-m1-14  # needs MPS, was macos-m1-stable
+      runner: macos-14  # needs MPS, was macos-m1-stable
       script: |
           set -x
           conda create -y -n test-evaluation-mps-macos python=3.10.11
@@ -145,7 +145,7 @@ jobs:
   test-multimodal-mps-macos:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
-      runner: macos-m1-14  # needs MPS, was macos-m1-stable
+      runner: macos-14  # needs MPS, was macos-m1-stable
       script: |
           set -x
           conda create -y -n test-multimodal-mps-macos python=3.10.11
@@ -173,7 +173,7 @@ jobs:
   test-native-mps-macos:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
-      runner: macos-m1-14  # needs MPS, was macos-m1-stable
+      runner: macos-14  # needs MPS, was macos-m1-stable
       script: |
           set -x
           conda create -y -n test-native-mps-macos python=3.10.11

--- a/.github/workflows/run-readme-pr-mps.yml
+++ b/.github/workflows/run-readme-pr-mps.yml
@@ -9,7 +9,7 @@ jobs:
   test-readme-mps-macos:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
-      runner: macos-m1-14
+      runner: macos-14
       timeout: 60
       script: |
           conda create -y -n test-readme-mps-macos python=3.10.11 llvm-openmp


### PR DESCRIPTION
Removing dependency on self-hosted macOS runners, in prep for migration to meta-pytorch org